### PR TITLE
feat: Multi-repository support via Linear team mapping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,13 @@ REDIS_URL=redis://localhost:6379
 # GitHub Configuration
 # Token needs 'repo' scope to clone private repos and push changes
 GITHUB_TOKEN=your_github_token_here
-DEFAULT_REPO_URL=https://github.com/duvo-ai/flowlint
+
+# Repository Mapping (Linear Team → GitHub Repo)
+# Option 1: Map Linear teams to specific repositories (recommended for multi-repo)
+# LINEAR_TEAM_REPOS={"FRONT":"https://github.com/org/frontend","BACK":"https://github.com/org/backend"}
+
+# Option 2: Single default repository (for single-repo setups)
+DEFAULT_REPO_URL=https://github.com/your-org/your-repo
 
 # Anthropic API Key (for Claude 3 Opus & Sonnet)
 ANTHROPIC_API_KEY=your_anthropic_key_here

--- a/README.md
+++ b/README.md
@@ -338,6 +338,46 @@ kubectl logs -l app=ralph-worker --tail=50
 
 ---
 
+## Multi-Repository Setup
+
+Ralph maps **Linear Teams to GitHub repositories**. This follows Linear's philosophy where each team owns their codebase.
+
+### Configuration
+
+Set the `LINEAR_TEAM_REPOS` environment variable as a JSON object mapping Linear team keys to repository URLs:
+
+```bash
+# Kubernetes secret
+kubectl create secret generic ralph-team-repos \
+  --from-literal=mapping='{"FRONT":"https://github.com/org/frontend","BACK":"https://github.com/org/backend","INFRA":"https://github.com/org/infrastructure"}'
+
+# Or in .env for local development
+LINEAR_TEAM_REPOS={"FRONT":"https://github.com/org/frontend","BACK":"https://github.com/org/backend"}
+```
+
+### How it works
+
+1. Linear issue is created with label "Ralph" in team "FRONT"
+2. Ralph receives webhook with `team.key = "FRONT"`
+3. Looks up `FRONT` in `LINEAR_TEAM_REPOS` → `https://github.com/org/frontend`
+4. Clones that repository, creates branch, pushes PR
+
+### Fallback behavior
+
+| Scenario | Behavior |
+|----------|----------|
+| Team key found in `LINEAR_TEAM_REPOS` | Uses mapped repository |
+| Team key not found, `DEFAULT_REPO_URL` set | Uses default repository |
+| Neither configured | Issue is ignored (logged as warning) |
+
+### Finding your Linear team keys
+
+Team keys are the short prefixes in issue identifiers (e.g., `FRONT-123` → team key is `FRONT`).
+
+You can also find them in Linear: **Settings → Teams → [Team Name] → Team key**
+
+---
+
 ## Configuration Reference
 
 ### Environment Variables

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -68,25 +68,75 @@ describe('POST /webhook', () => {
         expect(res.body).toEqual({ status: 'ignored' });
     });
 
-    it('should queue task for valid Ralph issue', async () => {
-        const body = { 
-            type: 'Issue', 
-            action: 'create', 
-            data: { 
+    it('should queue task for valid Ralph issue with DEFAULT_REPO_URL', async () => {
+        process.env.DEFAULT_REPO_URL = 'https://github.com/test/repo';
+        const body = {
+            type: 'Issue',
+            action: 'create',
+            data: {
                 id: '123',
                 title: 'Fix bug',
                 description: 'Fix it now',
                 identifier: '1',
-                labels: [{ name: 'Ralph' }] 
-            } 
+                labels: [{ name: 'Ralph' }]
+            }
         };
         const res = await request(app)
             .post('/webhook')
             .set('linear-signature', getSignature(body))
             .send(body);
-        
+
         expect(res.status).toBe(200);
         expect(res.body).toEqual({ status: 'queued' });
+    });
+
+    it('should use team-specific repo from LINEAR_TEAM_REPOS', async () => {
+        process.env.LINEAR_TEAM_REPOS = JSON.stringify({
+            'FRONT': 'https://github.com/org/frontend',
+            'BACK': 'https://github.com/org/backend'
+        });
+        const body = {
+            type: 'Issue',
+            action: 'create',
+            data: {
+                id: '456',
+                title: 'Add feature',
+                description: 'New feature',
+                identifier: 'FRONT-123',
+                team: { key: 'FRONT' },
+                labels: [{ name: 'Ralph' }]
+            }
+        };
+        const res = await request(app)
+            .post('/webhook')
+            .set('linear-signature', getSignature(body))
+            .send(body);
+
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({ status: 'queued' });
+    });
+
+    it('should ignore issue when no repo configured for team', async () => {
+        delete process.env.DEFAULT_REPO_URL;
+        process.env.LINEAR_TEAM_REPOS = JSON.stringify({ 'OTHER': 'https://github.com/org/other' });
+        const body = {
+            type: 'Issue',
+            action: 'create',
+            data: {
+                id: '789',
+                title: 'Unknown team issue',
+                identifier: 'UNK-1',
+                team: { key: 'UNKNOWN' },
+                labels: [{ name: 'Ralph' }]
+            }
+        };
+        const res = await request(app)
+            .post('/webhook')
+            .set('linear-signature', getSignature(body))
+            .send(body);
+
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({ status: 'ignored', reason: 'no_repo_configured' });
     });
 
     it('should return 200 OK for /health', async () => {


### PR DESCRIPTION
## Summary

- Adds `LINEAR_TEAM_REPOS` environment variable to map Linear team keys to GitHub repository URLs
- Falls back to `DEFAULT_REPO_URL` if team is not mapped
- Ignores issues if no repository is configured (logged as warning)

## How it works

```bash
# Configuration
LINEAR_TEAM_REPOS={"FRONT":"https://github.com/org/frontend","BACK":"https://github.com/org/backend"}

# Linear issue FRONT-123 with label "Ralph"
#   → team.key = "FRONT" 
#   → repoUrl = "https://github.com/org/frontend"
#   → PR goes to frontend repo
```

## Changes

- `src/server.ts`: Added `getTeamRepoMap()` and `getRepoForTeam()` functions
- `tests/server.test.ts`: 3 new tests for team mapping, fallback, and ignore behavior
- `.env.example`: Documented `LINEAR_TEAM_REPOS`
- `README.md`: New "Multi-Repository Setup" section

## Test plan

- [x] Unit tests pass
- [ ] Test with actual Linear webhook with team data
- [ ] Verify fallback to DEFAULT_REPO_URL works

🤖 Generated with [Claude Code](https://claude.ai/code)