### PR TITLE
feat(infra): enable automatic GitHub secrets creation via Terraform

### DIFF
--- a/infra/iam_github.tf
+++ b/infra/iam_github.tf
@@ -50,41 +50,40 @@ resource "google_service_account_iam_member" "workload_identity_user" {
 }
 
 # --- GitHub Secrets Configuration ---
-# Commented out: requires GitHub token with 'repo' scope
-# Manually set these secrets in GitHub repo settings if needed
+# Automatically creates GitHub Actions secrets using GitHub provider
 
-# resource "github_actions_secret" "gcp_project_id" {
-#   repository      = var.github_repo
-#   secret_name     = "GCP_PROJECT_ID"
-#   plaintext_value = var.project_id
-# }
+resource "github_actions_secret" "gcp_project_id" {
+  repository      = var.github_repo
+  secret_name     = "GCP_PROJECT_ID"
+  plaintext_value = var.project_id
+}
 
-# resource "github_actions_secret" "gcp_workload_identity_provider" {
-#   repository      = var.github_repo
-#   secret_name     = "GCP_WORKLOAD_IDENTITY_PROVIDER"
-#   plaintext_value = google_iam_workload_identity_pool_provider.github_provider.name
-# }
+resource "github_actions_secret" "gcp_workload_identity_provider" {
+  repository      = var.github_repo
+  secret_name     = "GCP_WORKLOAD_IDENTITY_PROVIDER"
+  plaintext_value = google_iam_workload_identity_pool_provider.github_provider.name
+}
 
-# resource "github_actions_secret" "gcp_service_account" {
-#   repository      = var.github_repo
-#   secret_name     = "GCP_SERVICE_ACCOUNT"
-#   plaintext_value = google_service_account.github_actions.email
-# }
+resource "github_actions_secret" "gcp_service_account" {
+  repository      = var.github_repo
+  secret_name     = "GCP_SERVICE_ACCOUNT"
+  plaintext_value = google_service_account.github_actions.email
+}
 
-# resource "github_actions_secret" "gke_cluster_name" {
-#   repository      = var.github_repo
-#   secret_name     = "GKE_CLUSTER_NAME"
-#   plaintext_value = google_container_cluster.primary.name
-# }
+resource "github_actions_secret" "gke_cluster_name" {
+  repository      = var.github_repo
+  secret_name     = "GKE_CLUSTER_NAME"
+  plaintext_value = google_container_cluster.primary.name
+}
 
-# resource "github_actions_secret" "gke_zone" {
-#   repository      = var.github_repo
-#   secret_name     = "GKE_ZONE"
-#   plaintext_value = var.zone
-# }
+resource "github_actions_secret" "gke_zone" {
+  repository      = var.github_repo
+  secret_name     = "GKE_ZONE"
+  plaintext_value = var.zone
+}
 
-# resource "github_actions_secret" "redis_url" {
-#   repository      = var.github_repo
-#   secret_name     = "REDIS_URL"
-#   plaintext_value = "redis://${google_redis_instance.cache.host}:${google_redis_instance.cache.port}"
-# }
+resource "github_actions_secret" "redis_url" {
+  repository      = var.github_repo
+  secret_name     = "REDIS_URL"
+  plaintext_value = "redis://${google_redis_instance.cache.host}:${google_redis_instance.cache.port}"
+}


### PR DESCRIPTION
Uncomment github_actions_secret resources to automatically create GitHub secrets. User has GitHub PAT configured in terraform.tfvars, so Terraform can create secrets automatically.

GitHub secrets that will be created:
- GCP_PROJECT_ID
- GCP_WORKLOAD_IDENTITY_PROVIDER
- GCP_SERVICE_ACCOUNT
- GKE_CLUSTER_NAME
- GKE_ZONE
- REDIS_URL