### PR TITLE
fix(ci): correct GitHub Actions workflow syntax

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,21 +23,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    # Setup gcloud CLI
-    # Option 1: Workload Identity (Preferred)
-    - id: 'auth-wif'
-      if: "${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER != '' }}"
+    # Authenticate to GCP using Workload Identity
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
       uses: 'google-github-actions/auth@v2'
       with:
         workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
         service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-
-    # Option 2: Service Account Key (Fallback)
-    - id: 'auth-key'
-      if: "${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER == '' }}"
-      uses: 'google-github-actions/auth@v2'
-      with:
-        credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v2'


### PR DESCRIPTION
Fix invalid workflow file syntax that was causing deployment workflow to fail.

## Problem

The deploy workflow was failing with errors:
```
Invalid workflow file: .github/workflows/deploy.yaml#L1
(Line: 29, Col: 11): Unrecognized named-value: 'secrets'
(Line: 37, Col: 11): Unrecognized named-value: 'secrets'
```

## Root Cause

The `secrets` context cannot be used directly in `if` conditions with `\${{ }}` syntax:
```yaml
# ❌ WRONG - causes error
if: "\${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER != '' }}"

# ✅ CORRECT (but not needed here)
if: secrets.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
```

## Solution

Since Workload Identity is already configured via Terraform and secrets are set up:
- Removed conditional authentication logic
- Simplified to single auth step that always uses Workload Identity
- Removed fallback to service account key (not configured)

## Changes

**Before:**
- Two auth steps with conditional logic
- Attempted to check if Workload Identity provider exists
- Had fallback to service account key

**After:**
- Single auth step using Workload Identity
- No conditional logic needed
- Cleaner, simpler workflow

## Testing

After merge, the workflow should:
1. ✅ Authenticate successfully using Workload Identity
2. ✅ Build Docker image
3. ✅ Push to GCR
4. ✅ Deploy to GKE

---

🤖 Generated with Claude Code