### PR TITLE
fix(ci): add OIDC token permission for Workload Identity

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,6 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
 
+    permissions:
+      contents: read
+      id-token: write  # Required for Workload Identity Federation
+
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
Fix Workload Identity authentication by adding required OIDC token permissions.

## Problem

Deployment workflow was failing with:
```
Error: google-github-actions/auth failed with: GitHub Actions did not inject 
$ACTIONS_ID_TOKEN_REQUEST_TOKEN or $ACTIONS_ID_TOKEN_REQUEST_URL into this job.
This most likely means the GitHub Actions workflow permissions are incorrect.
```

## Root Cause

GitHub Actions workflows need explicit permission to request OIDC tokens for Workload Identity Federation. Without the `id-token: write` permission, the workflow cannot obtain the token needed to authenticate to GCP.

## Solution

Added `permissions` section to the deployment job:

```yaml
permissions:
  contents: read      # For repository access
  id-token: write     # For requesting OIDC tokens
```

## Why This is Needed

Workload Identity Federation uses OpenID Connect (OIDC) to allow GitHub Actions to authenticate to GCP without long-lived service account keys. The workflow exchanges a short-lived OIDC token from GitHub for temporary GCP credentials.

For this exchange to work:
1. GitHub Actions must have permission to generate OIDC tokens (`id-token: write`)
2. The OIDC token is sent to GCP Workload Identity Pool
3. GCP verifies the token and grants temporary credentials
4. Workflow can now access GCP resources (GKE, GCR, etc.)

## Testing

After merge, the deployment workflow should:
- ✅ Successfully authenticate to GCP via Workload Identity
- ✅ Build Docker image
- ✅ Push to GCR
- ✅ Deploy to GKE

## References

- [Configuring OpenID Connect in Google Cloud Platform](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform)
- [Permissions for GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)

---

🤖 Generated with Claude Code