### PR TITLE
fix(helm): add missing _helpers.tpl template file

### DIFF
--- a/helm/ralph/templates/_helpers.tpl
+++ b/helm/ralph/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ralph.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "ralph.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ralph.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ralph.labels" -}}
+helm.sh/chart: {{ include "ralph.chart" . }}
+{{ include "ralph.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ralph.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ralph.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}


### PR DESCRIPTION
## Summary
Fixes Helm chart deployment error by adding the missing `_helpers.tpl` file.

## Problem
The Helm chart was failing with:
```
Error: template: ralph/templates/networkpolicy.yaml:4:11: executing "ralph/templates/networkpolicy.yaml" at <include "ralph.fullname" .>: error calling include: template: no template "ralph.fullname" associated with template "gotpl"
```

## Solution
Created `helm/ralph/templates/_helpers.tpl` with standard Helm helper templates:
- `ralph.name` - Chart name
- `ralph.fullname` - Full resource name
- `ralph.chart` - Chart name and version
- `ralph.labels` - Common labels
- `ralph.selectorLabels` - Selector labels

## Testing
These are standard Helm chart helpers used across all Kubernetes Helm charts.

Fixes the GitHub Actions deployment workflow error.