### PR TITLE
feat: Failed to build docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,9 @@ RUN npm ci
 COPY . .
 RUN npm run build
 
-# Create non-root user for security
-RUN groupadd --gid 1000 appuser && \
-    useradd --uid 1000 --gid 1000 --create-home appuser && \
-    chown -R appuser:appuser /app
+# Set ownership to existing node user for security (node user is pre-created in node:22-bookworm with UID/GID 1000)
+RUN chown -R node:node /app
 
-USER appuser
+USER node
 
 CMD ["node", "dist/server.js"]


### PR DESCRIPTION
+++ Run docker build \\

+++

#0 building with "default" instance using docker driver

#1 \[internal\] load build definition from Dockerfile

#1 transferring dockerfile: 988B done

#1 DONE 0.0s

#2 \[auth\] library/node:pull token for registry-1.docker.io

#2 DONE 0.0s

#3 \[internal\] load metadata for docker.io/library/node:22-bookworm

#3 DONE 0.5s

#4 \[internal\] load .dockerignore

#4 transferring context: 2B done

#4 DONE 0.0s

#5 \[internal\] load build context

#5 transferring context: 613.29kB 0.0s done

#5 DONE 0.0s

#6 \[1/8\] FROM docker.io/library/node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935

#6 resolve docker.io/library/node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935 done

#6 sha256:58b82c7153457434610289a1f61c4326cc9ea77b996a8e9b3cdd92c9814bd7e6 2.49kB / 2.49kB done

#6 sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935 6.41kB / 6.41kB done

#6 sha256:a08c488a9779570021138dacddb3138542f6632362b21bb14a7e5d5621e34258 6.74kB / 6.74kB done

#6 sha256:c1be109a62df95316ceac87ea501079f32e17f36b636865a860841b7db06100c 0B / 48.48MB 0.1s

#6 sha256:64538a062a61add8dc8b290fa69475e8902eb839c497a5f5dcd5a950422e493c 0B / 24.04MB 0.1s

#6 sha256:fd1872fa12cc6b1145803f1a0679ca26cc65fa1b4e0ee389bfb30267594736b6 0B / 64.40MB 0.1s

#6 sha256:c1be109a62df95316ceac87ea501079f32e17f36b636865a860841b7db06100c 6.29MB / 48.48MB 0.3s

#6 sha256:64538a062a61add8dc8b290fa69475e8902eb839c497a5f5dcd5a950422e493c 4.19MB / 24.04MB 0.3s

#6 sha256:fd1872fa12cc6b1145803f1a0679ca26cc65fa1b4e0ee389bfb30267594736b6 12.58MB / 64.40MB 0.3s

#6 sha256:64538a062a61add8dc8b290fa69475e8902eb839c497a5f5dcd5a950422e493c 8.39MB / 24.04MB 0.4s

#6 sha256:fd1872fa12cc6b1145803f1a0679ca26cc65fa1b4e0ee389bfb30267594736b6 16.78MB / 64.40MB 0.4s

#6 sha256:c1be109a62df95316ceac87ea501079f32e17f36b636865a860841b7db06100c 15.73MB / 48.48MB 0.6s

#6 sha256:64538a062a61add8dc8b290fa69475e8902eb839c497a5f5dcd5a950422e493c 13.63MB / 24.04MB 0.6s

#6 sha256:fd1872fa12cc6b1145803f1a0679ca26cc65fa1b4e0ee389bfb30267594736b6 26.21MB / 64.40MB 0.6s

#6 sha256:c1be109a62df95316ceac87ea501079f32e17f36b636865a860841b7db06100c 19.92MB / 48.48MB 0.7s

#6 sha256:fd1872fa12cc6b1145803f1a0679ca26cc65fa1b4e0ee389bfb30267594736b6 33.55MB / 64.40MB 0.7s

#6 sha256:c1be109a62df95316ceac87ea501079f32e17f36b636865a860841b7db06100c 23.07MB / 48.48MB 0.9s

#6 sha256:64538a062a61add8dc8b290fa69475e8902eb839c497a5f5dcd5a950422e493c 19.92MB / 24.04MB 0.9s

#6 sha256:fd1872fa12cc6b1145803f1a0679ca26cc65fa1b4e0ee389bfb30267594736b6 45.09MB / 64.40MB 0.9s

#6 sha256:c1be109a62df95316ceac87ea501079f32e17f36b636865a860841b7db06100c 26.21MB / 48.48MB 1.0s

#6 sha256:c1be109a62df95316ceac87ea501079f32e17f36b636865a860841b7db06100c 29.36MB / 48.48MB 1.1s

#6 sha256:64538a062a61add8dc8b290fa69475e8902eb839c497a5f5dcd5a950422e493c 22.02MB / 24.04MB 1.1s

#6 sha256:fd1872fa12cc6b1145803f1a0679ca26cc65fa1b4e0ee389bfb30267594736b6 56.62MB / 64.40MB 1.1s

#6 sha256:c1be109a62df95316ceac87ea501079f32e17f36b636865a860841b7db06100c 34.60MB / 48.48MB 1.3s

#6 sha256:64538a062a61add8dc8b290fa69475e8902eb839c497a5f5dcd5a950422e493c 24.04MB / 24.04MB 1.1s done

#6 sha256:fd1872fa12cc6b1145803f1a0679ca26cc65fa1b4e0ee389bfb30267594736b6 64.40MB / 64.40MB 1.2s done

#6 sha256:4925cf9d8be888d2b942e0479d921815942727632813c006bad6a067e6363663 2.10MB / 211.49MB 1.3s

#6 sha256:357cb6974fa00f5868ed182a039825412fca969c0988eb54c7114136aba26f0b 3.32kB / 3.32kB 1.2s done

#6 sha256:a6174c95fe7408545d8621aba806a8dce153306ae7f114bf6cfc66854efa5494 0B / 58.30MB 1.3s

#6 sha256:c1be109a62df95316ceac87ea501079f32e17f36b636865a860841b7db06100c 38.80MB / 48.48MB 1.5s

#6 sha256:a6174c95fe7408545d8621aba806a8dce153306ae7f114bf6cfc66854efa5494 14.68MB / 58.30MB 1.5s

#6 sha256:a6174c95fe7408545d8621aba806a8dce153306ae7f114bf6cfc66854efa5494 20.97MB / 58.30MB 1.6s

#6 sha256:c1be109a62df95316ceac87ea501079f32e17f36b636865a860841b7db06100c 44.04MB / 48.48MB 1.8s

#6 sha256:4925cf9d8be888d2b942e0479d921815942727632813c006bad6a067e6363663 14.68MB / 211.49MB 1.8s

#6 sha256:a6174c95fe7408545d8621aba806a8dce153306ae7f114bf6cfc66854efa5494 36.70MB / 58.30MB 1.8s

#6 sha256:a6174c95fe7408545d8621aba806a8dce153306ae7f114bf6cfc66854efa5494 48.23MB / 58.30MB 1.9s

#6 sha256:c1be109a62df95316ceac87ea501079f32e17f36b636865a860841b7db06100c 47.19MB / 48.48MB 2.0s

#6 sha256:a6174c95fe7408545d8621aba806a8dce153306ae7f114bf6cfc66854efa5494 58.30MB / 58.30MB 2.0s done

#6 sha256:737aff54b15787f7e024f1e1a146d3d7677be2f217565c88152937be519722ec 0B / 1.25MB 2.0s

#6 extracting sha256:c1be109a62df95316ceac87ea501079f32e17f36b636865a860841b7db06100c

#6 sha256:c1be109a62df95316ceac87ea501079f32e17f36b636865a860841b7db06100c 48.48MB / 48.48MB 2.0s done

#6 sha256:5e9e90c62a56b42994131b60a9afcd3851a32cabafa66d482444ab1dcbdbc620 446B / 446B 2.1s done

#6 sha256:4925cf9d8be888d2b942e0479d921815942727632813c006bad6a067e6363663 30.41MB / 211.49MB 2.2s

#6 sha256:737aff54b15787f7e024f1e1a146d3d7677be2f217565c88152937be519722ec 1.25MB / 1.25MB 2.1s done

#6 sha256:4925cf9d8be888d2b942e0479d921815942727632813c006bad6a067e6363663 46.14MB / 211.49MB 2.6s

#6 sha256:4925cf9d8be888d2b942e0479d921815942727632813c006bad6a067e6363663 57.74MB / 211.49MB 2.8s

#6 sha256:4925cf9d8be888d2b942e0479d921815942727632813c006bad6a067e6363663 73.40MB / 211.49MB 3.4s

#6 sha256:4925cf9d8be888d2b942e0479d921815942727632813c006bad6a067e6363663 89.13MB / 211.49MB 3.6s

#6 extracting sha256:c1be109a62df95316ceac87ea501079f32e17f36b636865a860841b7db06100c 1.6s done

#6 sha256:4925cf9d8be888d2b942e0479d921815942727632813c006bad6a067e6363663 102.76MB / 211.49MB 3.9s

#6 extracting sha256:64538a062a61add8dc8b290fa69475e8902eb839c497a5f5dcd5a950422e493c

#6 sha256:4925cf9d8be888d2b942e0479d921815942727632813c006bad6a067e6363663 118.49MB / 211.49MB 4.5s

#6 extracting sha256:64538a062a61add8dc8b290fa69475e8902eb839c497a5f5dcd5a950422e493c 0.5s done

#6 sha256:4925cf9d8be888d2b942e0479d921815942727632813c006bad6a067e6363663 133.17MB / 211.49MB 4.9s

#6 sha256:4925cf9d8be888d2b942e0479d921815942727632813c006bad6a067e6363663 146.80MB / 211.49MB 5.2s

#6 sha256:4925cf9d8be888d2b942e0479d921815942727632813c006bad6a067e6363663 162.53MB / 211.49MB 5.9s

#6 sha256:4925cf9d8be888d2b942e0479d921815942727632813c006bad6a067e6363663 176.16MB / 211.49MB 6.2s

#6 sha256:4925cf9d8be888d2b942e0479d921815942727632813c006bad6a067e6363663 189.79MB / 211.49MB 6.5s

#6 extracting sha256:fd1872fa12cc6b1145803f1a0679ca26cc65fa1b4e0ee389bfb30267594736b6 0.1s

#6 sha256:4925cf9d8be888d2b942e0479d921815942727632813c006bad6a067e6363663 208.67MB / 211.49MB 6.8s

#6 sha256:4925cf9d8be888d2b942e0479d921815942727632813c006bad6a067e6363663 211.49MB / 211.49MB 6.8s done

#6 extracting sha256:fd1872fa12cc6b1145803f1a0679ca26cc65fa1b4e0ee389bfb30267594736b6 2.1s done

#6 extracting sha256:4925cf9d8be888d2b942e0479d921815942727632813c006bad6a067e6363663

#6 extracting sha256:4925cf9d8be888d2b942e0479d921815942727632813c006bad6a067e6363663 5.0s done

#6 extracting sha256:357cb6974fa00f5868ed182a039825412fca969c0988eb54c7114136aba26f0b

#6 extracting sha256:357cb6974fa00f5868ed182a039825412fca969c0988eb54c7114136aba26f0b done

#6 extracting sha256:a6174c95fe7408545d8621aba806a8dce153306ae7f114bf6cfc66854efa5494 0.1s

#6 extracting sha256:a6174c95fe7408545d8621aba806a8dce153306ae7f114bf6cfc66854efa5494 2.0s done

#6 extracting sha256:737aff54b15787f7e024f1e1a146d3d7677be2f217565c88152937be519722ec

#6 extracting sha256:737aff54b15787f7e024f1e1a146d3d7677be2f217565c88152937be519722ec 0.0s done

#6 extracting sha256:5e9e90c62a56b42994131b60a9afcd3851a32cabafa66d482444ab1dcbdbc620 done

#6 DONE 17.6s

#7 \[2/8\] WORKDIR /app

#7 DONE 0.0s

#8 \[3/8\] RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-pip python3-venv git curl wget && rm -rf /var/lib/apt/lists/\* && pip3 install --no-cache-dir --break-system-packages ruff mypy uv && npm install -g @biomejs/biome typescript tsx && curl -sfL [https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh](<https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh>) | sh -s -- -b /usr/local/bin && curl -fsSL [https://claude.ai/install.sh](<https://claude.ai/install.sh>) | bash && install -m 755 /root/.local/bin/claude /usr/local/bin/claude

#8 0.184 Get:1 [http://deb.debian.org/debian](<http://deb.debian.org/debian>) bookworm InRelease \[151 kB\]

#8 0.200 Get:2 [http://deb.debian.org/debian](<http://deb.debian.org/debian>) bookworm-updates InRelease \[55.4 kB\]

#8 0.208 Get:3 [http://deb.debian.org/debian-security](<http://deb.debian.org/debian-security>) bookworm-security InRelease \[48.0 kB\]

#8 0.264 Get:4 [http://deb.debian.org/debian](<http://deb.debian.org/debian>) bookworm/main amd64 Packages \[8792 kB\]

#8 0.328 Get:5 [http://deb.debian.org/debian](<http://deb.debian.org/debian>) bookworm-updates/main amd64 Packages \[6924 B\]

#8 0.367 Get:6 [http://deb.debian.org/debian-security](<http://deb.debian.org/debian-security>) bookworm-security/main amd64 Packages \[293 kB\]

#8 1.083 Fetched 9346 kB in 1s (10.1 MB/s)

#8 1.083 Reading package lists...

#8 1.487 Reading package lists...

#8 1.888 Building dependency tree...

#8 1.985 Reading state information...

#8 2.077 python3 is already the newest version (3.11.2-1+b1).

#8 2.077 python3 set to manually installed.

#8 2.077 git is already the newest version (1:2.39.5-0+deb12u3).

#8 2.077 curl is already the newest version (7.88.1-10+deb12u14).

#8 2.077 wget is already the newest version (1.21.3-1+deb12u1).

#8 2.077 The following additional packages will be installed:

#8 2.077 python3-pip-whl python3-pkg-resources python3-setuptools

#8 2.077 python3-setuptools-whl python3-wheel python3.11-venv

#8 2.078 Suggested packages:

#8 2.078 python-setuptools-doc

#8 2.078 Recommended packages:

#8 2.078 build-essential python3-dev

#8 2.153 The following NEW packages will be installed:

#8 2.153 python3-pip python3-pip-whl python3-pkg-resources python3-setuptools

#8 2.154 python3-setuptools-whl python3-venv python3-wheel python3.11-venv

#8 2.178 0 upgraded, 8 newly installed, 0 to remove and 16 not upgraded.

#8 2.178 Need to get 5010 kB of archives.

#8 2.178 After this operation, 13.8 MB of additional disk space will be used.

#8 2.178 Get:1 [http://deb.debian.org/debian](<http://deb.debian.org/debian>) bookworm/main amd64 python3-pkg-resources all 66.1.1-1+deb12u2 \[297 kB\]

#8 2.198 Get:2 [http://deb.debian.org/debian](<http://deb.debian.org/debian>) bookworm/main amd64 python3-setuptools all 66.1.1-1+deb12u2 \[522 kB\]

#8 2.204 Get:3 [http://deb.debian.org/debian](<http://deb.debian.org/debian>) bookworm/main amd64 python3-wheel all 0.38.4-2 \[30.8 kB\]

#8 2.205 Get:4 [http://deb.debian.org/debian](<http://deb.debian.org/debian>) bookworm/main amd64 python3-pip all 23.0.1+dfsg-1 \[1325 kB\]

#8 2.212 Get:5 [http://deb.debian.org/debian](<http://deb.debian.org/debian>) bookworm/main amd64 python3-pip-whl all 23.0.1+dfsg-1 \[1717 kB\]

#8 2.219 Get:6 [http://deb.debian.org/debian](<http://deb.debian.org/debian>) bookworm/main amd64 python3-setuptools-whl all 66.1.1-1+deb12u2 \[1112 kB\]

#8 2.223 Get:7 [http://deb.debian.org/debian](<http://deb.debian.org/debian>) bookworm/main amd64 python3.11-venv amd64 3.11.2-6+deb12u6 \[5896 B\]

#8 2.223 Get:8 [http://deb.debian.org/debian](<http://deb.debian.org/debian>) bookworm/main amd64 python3-venv amd64 3.11.2-1+b1 \[1200 B\]

#8 2.333 debconf: delaying package configuration, since apt-utils is not installed

#8 2.356 Fetched 5010 kB in 0s (76.3 MB/s)

#8 2.371 Selecting previously unselected package python3-pkg-resources.

#8 2.371 (Reading database ...

(Reading database ... 5%

(Reading database ... 10%

(Reading database ... 15%

(Reading database ... 20%

(Reading database ... 25%

(Reading database ... 30%

(Reading database ... 35%

(Reading database ... 40%

(Reading database ... 45%

(Reading database ... 50%

(Reading database ... 55%

(Reading database ... 60%

(Reading database ... 65%

(Reading database ... 70%

(Reading database ... 75%

(Reading database ... 80%

(Reading database ... 85%

(Reading database ... 90%

(Reading database ... 95%

(Reading database ... 100%

(Reading database ... 23258 files and directories currently installed.)

#8 2.390 Preparing to unpack .../0-python3-pkg-resources_66.1.1-1+deb12u2_all.deb ...

#8 2.391 Unpacking python3-pkg-resources (66.1.1-1+deb12u2) ...

#8 2.427 Selecting previously unselected package python3-setuptools.

#8 2.430 Preparing to unpack .../1-python3-setuptools_66.1.1-1+deb12u2_all.deb ...

#8 2.431 Unpacking python3-setuptools (66.1.1-1+deb12u2) ...

#8 2.486 Selecting previously unselected package python3-wheel.

#8 2.489 Preparing to unpack .../2-python3-wheel_0.38.4-2_all.deb ...

#8 2.490 Unpacking python3-wheel (0.38.4-2) ...

#8 2.512 Selecting previously unselected package python3-pip.

#8 2.515 Preparing to unpack .../3-python3-pip_23.0.1+dfsg-1_all.deb ...

#8 2.516 Unpacking python3-pip (23.0.1+dfsg-1) ...

#8 2.661 Selecting previously unselected package python3-pip-whl.

#8 2.664 Preparing to unpack .../4-python3-pip-whl_23.0.1+dfsg-1_all.deb ...

#8 2.665 Unpacking python3-pip-whl (23.0.1+dfsg-1) ...

#8 2.752 Selecting previously unselected package python3-setuptools-whl.

#8 2.755 Preparing to unpack .../5-python3-setuptools-whl_66.1.1-1+deb12u2_all.deb ...

#8 2.756 Unpacking python3-setuptools-whl (66.1.1-1+deb12u2) ...

#8 2.812 Selecting previously unselected package python3.11-venv.

#8 2.814 Preparing to unpack .../6-python3.11-venv_3.11.2-6+deb12u6_amd64.deb ...

#8 2.815 Unpacking python3.11-venv (3.11.2-6+deb12u6) ...

#8 2.829 Selecting previously unselected package python3-venv.

#8 2.831 Preparing to unpack .../7-python3-venv_3.11.2-1+b1_amd64.deb ...

#8 2.832 Unpacking python3-venv (3.11.2-1+b1) ...

#8 2.851 Setting up python3-pkg-resources (66.1.1-1+deb12u2) ...

#8 3.053 Setting up python3-setuptools-whl (66.1.1-1+deb12u2) ...

#8 3.056 Setting up python3-setuptools (66.1.1-1+deb12u2) ...

#8 3.427 Setting up python3-pip-whl (23.0.1+dfsg-1) ...

#8 3.431 Setting up python3-wheel (0.38.4-2) ...

#8 3.542 Setting up python3.11-venv (3.11.2-6+deb12u6) ...

#8 3.583 Setting up python3-pip (23.0.1+dfsg-1) ...

#8 4.429 Setting up python3-venv (3.11.2-1+b1) ...

#8 5.486 Collecting ruff

#8 5.533 Downloading ruff-0.14.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (11.2 MB)

#8 5.754 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 11.2/11.2 MB 59.6 MB/s eta 0:00:00

#8 5.954 Collecting mypy

#8 5.962 Downloading mypy-1.19.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (13.4 MB)

#8 6.039 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 13.4/13.4 MB 192.5 MB/s eta 0:00:00

#8 6.527 Collecting uv

#8 6.535 Downloading uv-0.9.27-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (22.7 MB)

#8 6.610 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 22.7/22.7 MB 349.8 MB/s eta 0:00:00

#8 6.667 Collecting typing_extensions>=4.6.0

#8 6.674 Downloading typing_extensions-4.15.0-py3-none-any.whl (44 kB)

#8 6.676 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 44.6/44.6 kB 283.8 MB/s eta 0:00:00

#8 6.691 Collecting mypy_extensions>=1.0.0

#8 6.698 Downloading mypy_extensions-1.1.0-py3-none-any.whl (5.0 kB)

#8 6.717 Collecting pathspec>=0.9.0

#8 6.724 Downloading pathspec-1.0.4-py3-none-any.whl (55 kB)

#8 6.726 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 55.2/55.2 kB 306.5 MB/s eta 0:00:00

#8 6.903 Collecting librt>=0.6.2

#8 6.910 Downloading librt-0.7.8-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (188 kB)

#8 6.912 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 188.0/188.0 kB 327.3 MB/s eta 0:00:00

#8 6.946 Installing collected packages: uv, typing_extensions, ruff, pathspec, mypy_extensions, librt, mypy

#8 8.552 Successfully installed librt-0.7.8 mypy-1.19.1 mypy_extensions-1.1.0 pathspec-1.0.4 ruff-0.14.14 typing_extensions-4.15.0 uv-0.9.27

#8 8.552 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: [https://pip.pypa.io/warnings/venv](<https://pip.pypa.io/warnings/venv>)

#8 11.50

#8 11.50 added 8 packages in 3s

#8 11.50

#8 11.50 3 packages are looking for funding

#8 11.50 run \`npm fund\` for details

#8 11.50 npm notice

#8 11.50 npm notice New major version of npm available! 10.9.4 -> 11.8.0

#8 11.50 npm notice Changelog: [https://github.com/npm/cli/releases/tag/v11.8.0](<https://github.com/npm/cli/releases/tag/v11.8.0>)

#8 11.50 npm notice To update run: npm install -g npm@11.8.0

#8 11.50 npm notice

#8 11.63 aquasecurity/trivy info checking GitHub for latest tag

#8 11.69 aquasecurity/trivy info found version: 0.68.2 for v0.68.2/Linux/64bit

#8 13.38 aquasecurity/trivy info installed /usr/local/bin/trivy

#8 15.24 Setting up Claude Code...

#8 15.83 \[?2026h

#8 15.83 Checking installation status...

#8 15.83 \[?2026l\[?2026h

Installing Clude Cde nive buildlatest...

#8 15.88 \[?2026l\[?2026h

Seting uplauncher and shellintegration.

#8 17.55 \[?2026l\[?2026h

⚠ Setupnotes:

 • Native installation exists but \~/.local/bin is not in your PATH. Run:

#8 17.90

#8 17.90 echo 'export PATH="$HOME/.local/bin:$PATH"' >> your shell config file &&

#8 17.90 source your shell config file

#8 17.90

#8 17.90 \[?2026l\[?2026h

✔Clade Code successfullyinstalled!

Version:2.1.23

Lcation: \~/.local/bin/claud

#8 19.89 Next: Run claude --help to get started

#8 19.89

#8 19.89 ⚠ Setup notes:

#8 19.89 • Native installation exists but \~/.local/bin is not in your PATH. Run:

#8 19.89

#8 19.89 echo 'export PATH="$HOME/.local/bin:$PATH"' >> your shell config file &&

#8 19.89 source your shell config file

#8 19.89

#8 19.89 \[?2026l\[?2026h

#8 21.90 \[?2026l

#8 22.00 ✅ Installation complete!

#8 22.00

#8 DONE 23.0s

#9 \[4/8\] COPY package\*.json ./

#9 DONE 0.0s

#10 \[5/8\] RUN npm ci

#10 2.109 npm warn deprecated node-domexception@1.0.0: Use your platform's native DOMException instead

#10 2.173 npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.

#10 3.277 npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported

#10 4.708

#10 4.708 added 526 packages, and audited 527 packages in 5s

#10 4.708

#10 4.708 82 packages are looking for funding

#10 4.708 run \`npm fund\` for details

#10 4.709

#10 4.709 found 0 vulnerabilities

#10 DONE 4.8s

#11 \[6/8\] COPY . .

#11 DONE 0.2s

#12 \[7/8\] RUN npm run build

#12 0.217

#12 0.217 > ralph-platform@1.0.0 build

#12 0.217 > tsc

#12 0.217

#12 DONE 2.8s

#13 \[8/8\] RUN groupadd --gid 1000 appuser && useradd --uid 1000 --gid 1000 --create-home appuser && chown -R appuser:appuser /app

#13 0.160 groupadd: GID '1000' already exists

#13 ERROR: process "/bin/sh -c groupadd --gid 1000 appuser && useradd --uid 1000 --gid 1000 --create-home appuser && chown -R appuser:appuser /app" did not complete successfully: exit code: 4

\------

 > \[8/8\] RUN groupadd --gid 1000 appuser && useradd --uid 1000 --gid 1000 --create-home appuser && chown -R appuser:appuser /app:

0.160 groupadd: GID '1000' already exists

\------

Dockerfile:22

\--------------------

 21 | # Create non-root user for security

 22 | >>> RUN groupadd --gid 1000 appuser && \\

 23 | >>> useradd --uid 1000 --gid 1000 --create-home appuser && \\

 24 | >>> chown -R appuser:appuser /app

 25 |

\--------------------

ERROR: failed to build: failed to solve: process "/bin/sh -c groupadd --gid 1000 appuser && useradd --uid 1000 --gid 1000 --create-home appuser && chown -R appuser:appuser /app" did not complete successfully: exit code: 4

**Error:** Process completed with exit code 1.