### PR TITLE
feat: Add health check endpoint documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,44 @@ Ralph is designed for **development automation on trusted codebases**, not for r
 
 ---
 
+## API Endpoints
+
+### GET /health
+
+Health check endpoint to verify the API is running correctly.
+
+| Property | Value |
+|----------|-------|
+| **Method** | GET |
+| **Path** | `/health` |
+| **Authentication** | None |
+| **Response** | JSON |
+
+**Response Body:**
+```json
+{"status": "ok"}
+```
+
+**Example Request:**
+```bash
+curl http://localhost:3000/health
+```
+
+**Example Response:**
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"status":"ok"}
+```
+
+This endpoint is useful for:
+- Kubernetes liveness/readiness probes
+- Load balancer health checks
+- Verifying the API service is operational
+
+---
+
 ## Quick Start (Local Development)
 
 ```bash


### PR DESCRIPTION
Please update the [README.md](<http://README.md>) file to include documentation for the /health endpoint.

Requirements:

1. Locate the existing /health endpoint in src/server.ts to understand how it works.
2. Add a new section "API Endpoints" to [README.md](<http://README.md>) (if it doesn't exist).
3. Document the GET /health endpoint, including:
   * Method: GET
   * Path: /health
   * Expected Response: JSON {"status":"ok"}
   * Example curl command. This helps developers verify that the API is running correctly.