### PR TITLE
feat: SonarQube: Duplicated Lines (%) on New Code

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -260,30 +260,29 @@ if (!fs.existsSync(CLAUDE_CACHE_ROOT)) {
     }
 }
 
+async function syncDirectoryContents(sourceDir: string, targetDir: string, operation: string): Promise<void> {
+    if (!fs.existsSync(sourceDir)) return;
+
+    await fsPromises.mkdir(targetDir, { recursive: true });
+    const { execSync } = await import('node:child_process');
+    try {
+        execSync("cp -r " + sourceDir + "/* " + targetDir + "/");
+        console.log(operation + " Claude projects cache");
+    } catch (e: any) {
+        console.warn(operation + " failed: " + e.message);
+    }
+}
+
 async function seedClaudeCache(targetClaudeDir: string) {
     const projectsCache = path.join(CLAUDE_CACHE_ROOT, 'projects');
-    if (fs.existsSync(projectsCache)) {
-        const targetProjects = path.join(targetClaudeDir, 'projects');
-        await fsPromises.mkdir(targetProjects, { recursive: true });
-        const { execSync } = await import('node:child_process');
-        try {
-            execSync("cp -r " + projectsCache + "/* " + targetProjects + "/");
-            console.log("Seeded Claude projects cache from global storage");
-        } catch (e: any) { console.warn("Seed failed: " + e.message); }
-    }
+    const targetProjects = path.join(targetClaudeDir, 'projects');
+    await syncDirectoryContents(projectsCache, targetProjects, "Seeded");
 }
 
 async function persistClaudeCache(sourceClaudeDir: string) {
     const projectsSource = path.join(sourceClaudeDir, 'projects');
-    if (fs.existsSync(projectsSource)) {
-        const targetProjects = path.join(CLAUDE_CACHE_ROOT, 'projects');
-        await fsPromises.mkdir(targetProjects, { recursive: true });
-        const { execSync } = await import('node:child_process');
-        try {
-            execSync("cp -r " + projectsSource + "/* " + targetProjects + "/");
-            console.log("Persisted Claude projects cache to global storage");
-        } catch (e: any) { console.warn("Persistence failed: " + e.message); }
-    }
+    const targetProjects = path.join(CLAUDE_CACHE_ROOT, 'projects');
+    await syncDirectoryContents(projectsSource, targetProjects, "Persisted");
 }
 
 async function prepareClaudeSkills(workDir: string, homeDir: string) {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -50,70 +50,82 @@ function getSignature(body: any) {
         .digest('hex');
 }
 
+// Test helper: Send a webhook request with optional signature
+async function sendWebhook(body: any, options: { withSignature?: boolean; signature?: string } = {}) {
+    const req = request(app).post('/webhook');
+
+    if (options.signature) {
+        req.set('linear-signature', options.signature);
+    } else if (options.withSignature !== false) {
+        req.set('linear-signature', getSignature(body));
+    }
+
+    return req.send(body);
+}
+
+// Factory function: Create issue webhook payload
+function createIssueWebhook(data: {
+    id?: string;
+    title?: string;
+    description?: string;
+    identifier?: string;
+    labels?: { name: string }[];
+    team?: { key: string };
+}): any {
+    return {
+        type: 'Issue',
+        action: 'create',
+        data: {
+            id: data.id || '123',
+            title: data.title || 'Default title',
+            description: data.description,
+            identifier: data.identifier || 'TEST-1',
+            labels: data.labels || [],
+            team: data.team,
+        }
+    };
+}
+
 describe('POST /webhook', () => {
     it('should reject requests with missing signature', async () => {
-        const res = await request(app)
-            .post('/webhook')
-            .send({ type: 'Issue' });
-        
+        const res = await sendWebhook({ type: 'Issue' }, { withSignature: false });
         expect(res.status).toBe(401);
     });
 
     it('should reject requests with invalid signature', async () => {
-        const res = await request(app)
-            .post('/webhook')
-            .set('linear-signature', 'wrong')
-            .send({ type: 'Issue' });
-        
+        const res = await sendWebhook({ type: 'Issue' }, { signature: 'wrong' });
         expect(res.status).toBe(401);
     });
 
     it('should ignore non-issue events with valid signature', async () => {
         const body = { type: 'PullRequest', action: 'create', data: {} };
-        const res = await request(app)
-            .post('/webhook')
-            .set('linear-signature', getSignature(body))
-            .send(body);
-        
+        const res = await sendWebhook(body);
+
         expect(res.status).toBe(200);
         expect(res.body).toEqual({ status: 'ignored' });
     });
 
     it('should ignore issues without "Ralph" label', async () => {
-        const body = { 
-            type: 'Issue', 
-            action: 'create', 
-            data: { 
-                identifier: 'TEST-1',
-                labels: [{ name: 'bug' }] 
-            } 
-        };
-        const res = await request(app)
-            .post('/webhook')
-            .set('linear-signature', getSignature(body))
-            .send(body);
-        
+        const body = createIssueWebhook({
+            identifier: 'TEST-1',
+            labels: [{ name: 'bug' }]
+        });
+        const res = await sendWebhook(body);
+
         expect(res.status).toBe(200);
         expect(res.body).toEqual({ status: 'ignored', reason: 'no_ralph_label' });
     });
 
     it('should queue task for valid Ralph issue with DEFAULT_REPO_URL', async () => {
         process.env.DEFAULT_REPO_URL = 'https://github.com/test/repo';
-        const body = {
-            type: 'Issue',
-            action: 'create',
-            data: {
-                id: '123',
-                title: 'Fix bug',
-                description: 'Fix it now',
-                identifier: '1',
-                labels: [{ name: 'Ralph' }]
-            }
-        };
-        const res = await request(app)
-            .post('/webhook')
-            .set('linear-signature', getSignature(body))
-            .send(body);
+        const body = createIssueWebhook({
+            id: '123',
+            title: 'Fix bug',
+            description: 'Fix it now',
+            identifier: '1',
+            labels: [{ name: 'Ralph' }]
+        });
+        const res = await sendWebhook(body);
 
         expect(res.status).toBe(200);
         expect(res.body).toEqual({ status: 'queued' });
@@ -124,22 +136,15 @@ describe('POST /webhook', () => {
             'FRONT': 'https://github.com/org/frontend',
             'BACK': 'https://github.com/org/backend'
         });
-        const body = {
-            type: 'Issue',
-            action: 'create',
-            data: {
-                id: '456',
-                title: 'Add feature',
-                description: 'New feature',
-                identifier: 'FRONT-123',
-                team: { key: 'FRONT' },
-                labels: [{ name: 'Ralph' }]
-            }
-        };
-        const res = await request(app)
-            .post('/webhook')
-            .set('linear-signature', getSignature(body))
-            .send(body);
+        const body = createIssueWebhook({
+            id: '456',
+            title: 'Add feature',
+            description: 'New feature',
+            identifier: 'FRONT-123',
+            team: { key: 'FRONT' },
+            labels: [{ name: 'Ralph' }]
+        });
+        const res = await sendWebhook(body);
 
         expect(res.status).toBe(200);
         expect(res.body).toEqual({ status: 'queued' });
@@ -148,21 +153,14 @@ describe('POST /webhook', () => {
     it('should ignore issue when no repo configured for team', async () => {
         delete process.env.DEFAULT_REPO_URL;
         process.env.LINEAR_TEAM_REPOS = JSON.stringify({ 'OTHER': 'https://github.com/org/other' });
-        const body = {
-            type: 'Issue',
-            action: 'create',
-            data: {
-                id: '789',
-                title: 'Unknown team issue',
-                identifier: 'UNK-1',
-                team: { key: 'UNKNOWN' },
-                labels: [{ name: 'Ralph' }]
-            }
-        };
-        const res = await request(app)
-            .post('/webhook')
-            .set('linear-signature', getSignature(body))
-            .send(body);
+        const body = createIssueWebhook({
+            id: '789',
+            title: 'Unknown team issue',
+            identifier: 'UNK-1',
+            team: { key: 'UNKNOWN' },
+            labels: [{ name: 'Ralph' }]
+        });
+        const res = await sendWebhook(body);
 
         expect(res.status).toBe(200);
         expect(res.body).toEqual({ status: 'ignored', reason: 'no_repo_configured' });


### PR DESCRIPTION
[https://github.com/Replikanti/ralph-platform/pull/92](<https://github.com/Replikanti/ralph-platform/pull/92>)

**Duplicated Lines (%) on New Code**12.8%

|  | Duplicated Lines (%) on New Code | Duplicated Lines on New Code |
| -- | -- | -- |
| [**tests/server.test.ts**](<https://sonarcloud.io/component_measures?id=Replikanti_ralph-platform&metric=new_duplicated_lines_density&pullRequest=93&selected=Replikanti_ralph-platform%253Atests%252Fserver.test.ts>) | 60.9% | 95 |
| [**src/linear-client.ts**](<https://sonarcloud.io/component_measures?id=Replikanti_ralph-platform&metric=new_duplicated_lines_density&pullRequest=93&selected=Replikanti_ralph-platform%253Asrc%252Flinear-client.ts>) | 21.4% | 22 |
| [**src/agent.ts**](<https://sonarcloud.io/component_measures?id=Replikanti_ralph-platform&metric=new_duplicated_lines_density&pullRequest=93&selected=Replikanti_ralph-platform%253Asrc%252Fagent.ts>) | 1.3% | 2 |
