### PR TITLE
docs: update model usage and add cost optimization details

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,13 +1,13 @@
 # Ralph Platform - AI Coding Agent
 
-Ralph is an event-driven AI coding agent platform that automates software development tasks. It processes Linear issues, utilizes Claude AI (Opus for planning, Sonnet for execution) to generate code, validates changes using polyglot toolchains, and pushes pull requests to GitHub.
+Ralph is an event-driven AI coding agent platform that automates software development tasks. It processes Linear issues, utilizes Claude AI (Sonnet 4.5 for planning and execution with budget limits, Haiku 4.5 for error summarization) to generate code, validates changes using polyglot toolchains, and pushes pull requests to GitHub.
 
 ## Project Overview
 
 *   **Type:** TypeScript / Node.js Application
 *   **Architecture:** Event-driven microservices (API + Worker) backed by Redis.
 *   **Infrastructure:** Kubernetes (GKE), Terraform, Helm.
-*   **AI Models:** Anthropic Claude (Opus & Sonnet).
+*   **AI Models:** Anthropic Claude (Sonnet 4.5 for planning & coding, Haiku 4.5 for error summarization).
 
 ## Architecture & Data Flow
 
@@ -16,7 +16,7 @@ Ralph is an event-driven AI coding agent platform that automates software develo
 3.  **Worker Service (`src/worker.ts`):** Dequeues the task and initializes the Agent.
 4.  **Agent (`src/agent.ts`):**
     *   **Workspace:** Clones the target repository into an ephemeral directory (`/tmp/ralph-workspaces`).
-    *   **Planning:** Uses Claude Opus to create an implementation plan.
+    *   **Planning:** Uses Claude Sonnet 4.5 to create an implementation plan ($0.50 budget limit).
     *   **Coding:** Uses Claude Sonnet to generate code based on the plan.
     *   **Validation:** Runs language-specific tools (Biome, TSC, Ruff, Mypy) via `src/tools.ts`.
 5.  **Output:** Commits changes and pushes a new branch/PR to GitHub.

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -20,7 +20,7 @@ Successfully implemented interactive planning with human steering for the Ralph 
    - Includes state synonym mapping for "plan-review"
 
 3. **src/plan-formatter.ts** - Plan formatting utility
-   - Converts Opus XML plans to readable Markdown
+   - Converts Sonnet 4.5 XML plans to readable Markdown
    - Includes approval instructions
    - Formats for Linear display
 
@@ -89,7 +89,7 @@ Todo → Plan Review → In Progress → In Review → Done
    - Other text → Re-planning job with feedback
 
 ### Data Flow
-1. Opus generates plan → Store in Redis
+1. Sonnet 4.5 generates plan → Store in Redis
 2. Post formatted plan to Linear
 3. Human reviews → Comments on issue
 4. Webhook processes comment → Enqueue appropriate job

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Ralph is an event-driven AI coding agent that automatically processes Linear iss
 ## 🎯 What is Ralph?
 
 Ralph automates the software development workflow by:
-- **Planning** with Claude Opus (strategic, high-level)
-- **Coding** with Claude Sonnet (tactical, implementation)
+- **Planning** with Claude Sonnet 4.5 (implementation plans with $0.50 budget limit)
+- **Coding** with Claude Sonnet 4.5 (code execution with $2.00 budget limit)
+- **Error Summarization** with Claude Haiku 4.5 (cost-efficient failure analysis with $0.10 budget)
 - **Validating** with polyglot tools (Biome, TSC, Ruff, Mypy, Semgrep)
 - **Iterating** based on human feedback and CI results
 
@@ -16,6 +17,7 @@ Ralph automates the software development workflow by:
 - **PR Iteration Workflow** - Continuously improve PRs with CI/SonarQube feedback
 - **Multi-Repository Support** - Map Linear teams to different GitHub repositories
 - **Polyglot Validation** - Auto-detect and validate TypeScript, JavaScript, and Python projects
+- **Cost-Optimized** - Budget limits per phase, Haiku for summaries, TOON format for token reduction
 - **Security-First** - Command allowlists, sandbox isolation, secret scanning
 - **Observable** - Full tracing with Langfuse
 
@@ -143,8 +145,9 @@ graph LR
     Linear[Linear Webhook] -->|POST| API[API Server]
     API -->|Enqueue| Redis[(Redis)]
     Redis -->|Dequeue| Worker[Worker]
-    Worker -->|Plan| Opus[Claude Opus]
-    Worker -->|Code| Sonnet[Claude Sonnet]
+    Worker -->|Plan $0.50| Sonnet[Claude Sonnet 4.5]
+    Worker -->|Code $2.00| Sonnet
+    Worker -->|Summarize $0.10| Haiku[Claude Haiku 4.5]
     Worker -->|Validate| Tools[Polyglot Tools]
     Worker -->|Push| GitHub[GitHub PR]
     Worker -->|Trace| Langfuse[Langfuse]

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -25,7 +25,7 @@ Description:
 
 Ralph will:
 1. Move ticket to "In Progress"
-2. Generate implementation plan using Claude Opus
+2. Generate implementation plan using Claude Sonnet 4.5 ($0.50 budget limit)
 3. Post plan as comment
 4. Move ticket to "plan-review" state
 


### PR DESCRIPTION
Corrects outdated references to Claude Opus throughout documentation.

Actual model usage:
- Planning: Sonnet 4.5 ($0.50 budget limit)
- Execution: Sonnet 4.5 ($2.00 budget limit)
- Error summarization: Haiku 4.5 ($0.10 budget limit)

New Cost Optimizations section in ARCHITECTURE.md:
- Model selection strategy by task complexity
- TOON format (Token-Optimized Object Notation) for ~30-40% token reduction
- MCP toonify server (src/mcp-toonify.ts) for JSON→TOON conversion
- Token-optimized skills (/project-map, /trace-deps, /test-filter)
- Hard budget enforcement via --max-budget-usd flags

Updated files:
- README.md: Model references, added cost optimization to features
- ARCHITECTURE.md: All sequence diagrams, new Cost Optimizations section
- USER_GUIDE.md: Planning step model reference
- CLAUDE.md: All model references throughout
- GEMINI.md: Model references
- IMPLEMENTATION_SUMMARY.md: Plan formatting references