### PR TITLE
docs: replace Semgrep with Trivy in all documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -164,7 +164,7 @@ const SECURITY_GUARDRAILS = `
 **Auto-Detection**:
 - **TypeScript/JavaScript**: Biome + TSC
 - **Python**: Ruff + Mypy
-- **Security**: Semgrep (all projects)
+- **Security**: Trivy (vulnerabilities, secrets, misconfigurations - MIT license)
 
 **Validation Flow**:
 1. Detect project type (`package.json`, `pyproject.toml`, etc.)
@@ -174,6 +174,14 @@ const SECURITY_GUARDRAILS = `
 5. Return aggregated results
 
 **Failures**: Still push to GitHub with `wip:` prefix to preserve work
+
+**License Compliance**: All validation tools use permissive licenses (MIT/Apache):
+- Biome: MIT
+- Ruff: MIT
+- Mypy: MIT
+- Trivy: Apache 2.0
+
+Note: Semgrep (GnuGPLv2) was intentionally replaced with Trivy to maintain license compatibility.
 
 ### Linear Client (`src/linear-client.ts`)
 
@@ -416,7 +424,7 @@ graph TD
     Resources --> Validation
     Paths --> Validation
 
-    Validation --> Scanning[Secret Scanning<br/>Trivy/Semgrep]
+    Validation --> Scanning[Security Scanning<br/>Trivy]
     Scanning --> GitHub[GitHub PR]
 
     style Webhook fill:#f9f,stroke:#333

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Ralph is an event-driven AI coding agent platform that receives tasks from Linea
 - **Worker** (src/worker.ts): Dequeues tasks from Redis, orchestrates agent execution
 - **Agent** (src/agent.ts): Core AI workflow - planning (Sonnet 4.5, $0.50), coding (Sonnet 4.5, $2.00), error summarization (Haiku 4.5, $0.10), validation (polyglot tools)
 - **Workspace** (src/workspace.ts): Manages ephemeral Git workspaces in `/tmp/ralph-workspaces`
-- **Tools** (src/tools.ts): Polyglot validation (Biome, TSC, Ruff, Mypy, Semgrep)
+- **Tools** (src/tools.ts): Polyglot validation (Biome, TSC, Ruff, Mypy, Trivy)
 - **Plan Store** (src/plan-store.ts): Redis-based persistence for human-in-the-loop plan reviews
 - **Linear Client** (src/linear-client.ts): Integration for posting plans and updating issue states
 - **Linear Utils** (src/linear-utils.ts): Shared utilities including state synonym mapping
@@ -257,7 +257,7 @@ The `runCommand` tool implements defense-in-depth against command injection:
 The tools module (src/tools.ts) auto-detects project type and runs:
 - **TypeScript/JavaScript**: Biome (formatting/linting with auto-fix) + TSC (type checking)
 - **Python**: Ruff (linting + formatting with auto-fix) + Mypy (type checking with `--ignore-missing-imports`)
-- **Security**: Semgrep with auto config (runs on all projects)
+- **Security**: Trivy (vulnerability, secret, and misconfiguration scanning - MIT license)
 
 Validation failures still result in a push (with "wip:" prefix) to preserve work.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Ralph automates the software development workflow by:
 - **Planning** with Claude Sonnet 4.5 (implementation plans with $0.50 budget limit)
 - **Coding** with Claude Sonnet 4.5 (code execution with $2.00 budget limit)
 - **Error Summarization** with Claude Haiku 4.5 (cost-efficient failure analysis with $0.10 budget)
-- **Validating** with polyglot tools (Biome, TSC, Ruff, Mypy, Semgrep)
+- **Validating** with polyglot tools (Biome, TSC, Ruff, Mypy, Trivy)
 - **Iterating** based on human feedback and CI results
 
 ## ✨ Key Features

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -40,7 +40,7 @@ Review the posted plan and reply with:
 After approval:
 1. Moves ticket to "In Progress"
 2. Implements code using Claude Sonnet
-3. Runs validation (Biome, TSC, Ruff, Mypy, Semgrep)
+3. Runs validation (Biome, TSC, Ruff, Mypy, Trivy)
 4. Creates pull request
 5. Moves ticket to "In Review"
 


### PR DESCRIPTION
License compliance: Semgrep uses GnuGPLv2 which doesn't meet project requirements. Replaced with Trivy (Apache 2.0) for security scanning.

Trivy provides:
- Vulnerability scanning
- Secret detection
- Misconfiguration detection
- Apache 2.0 license (compatible with MIT/Apache policy)

Changes:
- README.md: Updated validation tools list
- ARCHITECTURE.md: Updated tools section, security diagram, added license compliance note
- USER_GUIDE.md: Updated validation step
- CLAUDE.md: Updated tools references (2 locations)

All validation tools now use permissive licenses:
- Biome: MIT
- Ruff: MIT
- Mypy: MIT
- Trivy: Apache 2.0