### PR TITLE
ci: skip CI/deployment on documentation-only changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,19 @@ name: CI
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/workflows/**'
+      - 'LICENSE'
+      - '.gitignore'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/workflows/**'
+      - 'LICENSE'
+      - '.gitignore'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,6 +6,12 @@ on:
       - main
     tags:
       - 'v*'
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/workflows/**'
+      - 'LICENSE'
+      - '.gitignore'
 
 env:
   PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}


### PR DESCRIPTION
Add path filters to GitHub Actions workflows to prevent unnecessary CI runs and GKE deployments when only documentation is modified.

Ignored paths:
- **.md (all markdown files)
- docs/** (documentation directory)
- .github/workflows/** (workflow changes)
- LICENSE
- .gitignore

This reduces:
- CI execution time and GitHub Actions minutes
- Unnecessary Docker builds
- GKE deployment operations
- Overall cloud costs

Workflows affected:
- ci.yaml: Tests now skip on docs-only PRs/pushes
- deploy.yaml: GKE deployment skips on docs-only changes to main