### PR TITLE
fix: prevent auto-execution and use default Linear states

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -521,9 +521,9 @@ async function handlePlanOnlyMode(
     const formattedPlan = formatPlanForLinear(plan, task.title);
     await linearClient.postComment(task.ticketId, formattedPlan);
 
-    // Update issue state to plan-review
-    await linearClient.updateIssueState(task.ticketId, "plan-review");
-
+    // Keep ticket in "In Progress" state - plan is posted, awaiting approval
+    // (Don't move to "In Review" yet - that's for when PR is created)
+    console.log("📋 Plan posted to Linear (ticket stays in In Progress, awaiting approval)");
     console.log("✅ Plan posted to Linear, awaiting human approval");
 }
 


### PR DESCRIPTION
Critical fixes for human-in-the-loop workflow:

1. **Prevent auto-execution**: Ralph's own comments containing approval keywords (LGTM, approved, proceed, ship it) in the plan instructions were triggering automatic execution. Added filters to ignore:
   - Comments from Ralph Bot / bot users
   - Comments containing Ralph's signature patterns
   - Prevents race condition where plan comment triggers execution

2. **Use default Linear states**: Removed dependency on custom "plan-review" state that doesn't exist in Linear workspaces. Now uses default states:
   - Plan posted → stays in "In Progress" (awaiting approval)
   - PR created → moves to "In Review"
   - Removed isStateInPlanReview() function (no longer needed)
   - Removed plan-review state checks from webhook handler

Changes:
- src/server.ts: Added Ralph comment detection and filtering
- src/agent.ts: Removed updateIssueState("plan-review") call
- tests/server.test.ts: Added test for Ralph comment filtering

This fixes the workflow where Ralph was immediately executing after posting a plan instead of waiting for human approval.