### PR TITLE
chore: fix SonarQube false positive on test comment

### DIFF
--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -230,7 +230,7 @@ describe('runAgent', () => {
                 title: expect.stringContaining('wip:')
             }));
 
-            // Verify that ticket state was updated to "Todo"
+            // Verify ticket moved back to backlog state
             expect(mockUpdateIssueState).toHaveBeenCalledWith('1', 'Todo');
             // Should have added an explanation comment
             expect(mockPostComment).toHaveBeenCalledWith('1', expect.stringContaining('Ralph tried to fix X'));


### PR DESCRIPTION
SonarQube incorrectly flagged a test comment as a TODO that needs implementation because it contained the word "Todo" (a Linear state name).

The functionality IS fully implemented in src/agent.ts:368 where handleFailureFallback() updates the ticket state to "Todo" on failure.

Changed comment from:
  "Verify that ticket state was updated to 'Todo'"
to:
  "Verify ticket moved back to backlog state"

This resolves the false positive while maintaining test clarity.