### PR TITLE
fix: prevent auto-execution from Ralph's own comments

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -542,9 +542,9 @@ async function handlePlanOnlyMode(
     const formattedPlan = formatPlanForLinear(plan, task.title);
     await linearClient.postComment(task.ticketId, formattedPlan);
 
-    // Update issue state to plan-review
-    await linearClient.updateIssueState(task.ticketId, "plan-review");
-
+    // Keep ticket in "In Progress" state - plan is posted, awaiting approval
+    // (Don't move to "In Review" yet - that's for when PR is created)
+    console.log("📋 Plan posted to Linear (ticket stays in In Progress, awaiting approval)");
     console.log("✅ Plan posted to Linear, awaiting human approval");
 }
 


### PR DESCRIPTION
Critical fix for human-in-the-loop workflow where Ralph was immediately executing plans without waiting for human approval.

Problem:
Ralph posts a plan comment containing approval keywords (LGTM, approved, proceed, ship it) in the instructions. Linear sends a webhook for the comment creation, and the webhook handler detects these keywords and immediately enqueues an execution job, thinking the user approved.

Solution:
1. Filter Ralph's own comments before processing approval detection
   - Check comment author for "ralph", "bot" keywords
   - Check comment body for Ralph's signature patterns
   - Return early with status: 'ignored', reason: 'ralph_comment'

2. Remove dependency on non-existent "plan-review" state
   - Keep ticket in "In Progress" after posting plan
   - Move to "In Review" only when PR is created
   - Removed updateIssueState("plan-review") call from agent

Changes:
- src/server.ts: Added Ralph comment detection in handleCommentWebhook()
- src/agent.ts: Removed plan-review state transition
- tests/server.test.ts: Added test for Ralph comment filtering

This ensures Ralph waits for human approval before executing plans.