### PR TITLE
refactor: replace golangci-lint with staticcheck for MIT license comp…

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -173,7 +173,7 @@ const SECURITY_GUARDRAILS = `
 **Auto-Detection**:
 - **TypeScript/JavaScript**: Biome + TSC
 - **Python**: Ruff + Mypy
-- **Go**: goimports + golangci-lint + go build
+- **Go**: goimports + staticcheck + go build
 - **Terraform**: terraform fmt + terraform validate + tflint
 - **Security**: Trivy (vulnerabilities, secrets, misconfigurations - supports all languages)
 
@@ -193,7 +193,7 @@ const SECURITY_GUARDRAILS = `
 - Ruff: MIT
 - Mypy: MIT
 - goimports: BSD-3-Clause
-- golangci-lint: GPL-3.0 (linter aggregator)
+- staticcheck: MIT
 - go toolchain: BSD-3-Clause
 - Terraform: MPL-2.0 (Mozilla Public License)
 - tflint: MPL-2.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Ralph is an event-driven AI coding agent platform that receives tasks from Linea
 - **Worker** (src/worker.ts): Dequeues tasks from Redis, orchestrates agent execution
 - **Agent** (src/agent.ts): Core AI workflow - planning (Sonnet 4.5, $0.50), coding (Sonnet 4.5, $2.00), error summarization (Haiku 4.5, $0.10), validation (polyglot tools)
 - **Workspace** (src/workspace.ts): Manages ephemeral Git workspaces in `/tmp/ralph-workspaces`
-- **Tools** (src/tools.ts): Polyglot validation (Biome, TSC, Ruff, Mypy, goimports, golangci-lint, go build, terraform, tflint, Trivy)
+- **Tools** (src/tools.ts): Polyglot validation (Biome, TSC, Ruff, Mypy, goimports, staticcheck, go build, terraform, tflint, Trivy)
 - **Plan Store** (src/plan-store.ts): Redis-based persistence for human-in-the-loop plan reviews
 - **Linear Client** (src/linear-client.ts): Integration for posting plans and updating issue states
 - **Linear Utils** (src/linear-utils.ts): Shared utilities including state synonym mapping
@@ -273,7 +273,7 @@ The `runCommand` tool implements defense-in-depth against command injection:
    - Version control: `git status`, `git log`, `git diff`, `git show`
    - File operations: `ls`, `cat`, `pwd`, `echo`
    - Testing: `pytest`, `python -m pytest`
-   - Linters: `ruff`, `mypy`, `golangci-lint`, `tflint`
+   - Linters: `ruff`, `mypy`, `staticcheck`, `tflint`
    - Go tools: `go build`, `go test`, `go mod`, `go vet`, `go run`, `go fmt`, `gofmt`, `goimports`
    - Terraform tools: `terraform init`, `terraform fmt`, `terraform validate`, `terraform plan`
 
@@ -296,7 +296,7 @@ The `runCommand` tool implements defense-in-depth against command injection:
 The tools module (src/tools.ts) auto-detects project type and runs:
 - **TypeScript/JavaScript**: Biome (formatting/linting with auto-fix) + TSC (type checking)
 - **Python**: Ruff (linting + formatting with auto-fix) + Mypy (type checking with `--ignore-missing-imports`)
-- **Go**: goimports (formatting/imports with auto-fix) + golangci-lint (linting with partial auto-fix) + go build (compilation check)
+- **Go**: goimports (formatting/imports with auto-fix) + staticcheck (linting - MIT licensed) + go build (compilation check)
 - **Terraform**: terraform fmt (formatting with auto-fix) + terraform validate (syntax validation) + tflint (linting with partial auto-fix)
 - **Security**: Trivy (vulnerability, secret, and misconfiguration scanning - supports Go, Python, JS/TS, Terraform)
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -15,7 +15,7 @@ This guide covers deploying Ralph to Google Cloud Platform (GKE) with Terraform 
 | `docker` | latest | [Install Guide](https://docs.docker.com/get-docker/) |
 | `go` | 1.23.5 | Included in Docker image |
 | `goimports` | latest | Included in Docker image |
-| `golangci-lint` | 1.56.2 | Included in Docker image |
+| `staticcheck` | latest | Included in Docker image |
 | `terraform` | 1.7.5 | Included in Docker image |
 | `tflint` | 0.53.0 | Included in Docker image |
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 # Install Go, Terraform, Python, Node Tools, Trivy & Claude CLI
 RUN curl -fsSL https://go.dev/dl/go1.23.5.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
     go install golang.org/x/tools/cmd/goimports@latest && \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.56.2 && \
+    go install honnef.co/go/tools/cmd/staticcheck@latest && \
     apt-get update && \
     apt-get install -y --no-install-recommends python3 python3-pip python3-venv git curl wget unzip && \
     rm -rf /var/lib/apt/lists/* && \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Ralph automates the software development workflow by:
 - **Planning** with Claude Sonnet 4.5 (implementation plans with $0.50 budget limit)
 - **Coding** with Claude Sonnet 4.5 (code execution with $2.00 budget limit)
 - **Error Summarization** with Claude Haiku 4.5 (cost-efficient failure analysis with $0.10 budget)
-- **Validating** with polyglot tools (Biome, TSC, Ruff, Mypy, goimports, golangci-lint, terraform, tflint, Trivy)
+- **Validating** with polyglot tools (Biome, TSC, Ruff, Mypy, goimports, staticcheck, terraform, tflint, Trivy)
 - **Iterating** based on human feedback and CI results
 
 ## ✨ Key Features

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -360,7 +360,7 @@ You: "LGTM"
 
 Ralph: Creates PR with implementation
   - Runs goimports for formatting
-  - Runs golangci-lint for code quality
+  - Runs staticcheck for code quality
   - Runs go build to verify compilation
   - Runs Trivy for security scanning
 ```

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -332,7 +332,7 @@ async function validateGo(workDir: string, changedFiles: string[]): Promise<{ su
 
     // Run validation tools
     const goimportsResult = await runValidationTool('goimports -w .', 'goimports', workDir, changedFiles);
-    const lintResult = await runValidationTool('golangci-lint run --fix --timeout 5m', 'golangci-lint', workDir, changedFiles, 300000);
+    const lintResult = await runValidationTool('staticcheck ./...', 'staticcheck', workDir, changedFiles, 300000);
     const buildResult = await runValidationTool('go build ./...', 'go build', workDir, changedFiles, 120000);
 
     return {


### PR DESCRIPTION
…liance

BREAKING: Changes Go linting tool from golangci-lint to staticcheck

Reason:
- golangci-lint uses GPL-3.0 license (copyleft)
- GPL-3.0 poses restrictions for enterprise/commercial use
- staticcheck is MIT licensed (permissive, enterprise-friendly)
- staticcheck is officially supported by Go team at Google

Changes:
- Dockerfile: Install staticcheck instead of golangci-lint
- src/tools.ts: Use 'staticcheck ./...' command
- Documentation: Update all references to staticcheck
  - ARCHITECTURE.md: License compliance section
  - DEPLOYMENT.md: Prerequisites table
  - CLAUDE.md: Tool references
  - USER_GUIDE.md: Go example
  - README.md: Features list

License Note:
- BSD-3-Clause (goimports, Go toolchain) is permissive and OK for enterprise
- All Ralph validation tools now use permissive licenses only: MIT, Apache 2.0, BSD-3-Clause, MPL-2.0