### PR TITLE
docs: Fix Defense in Depth diagram colors and remove WIP prefix references

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -186,7 +186,7 @@ const SECURITY_GUARDRAILS = `
 6. Run security scanners
 7. Return aggregated results
 
-**Failures**: Still push to GitHub with `wip:` prefix to preserve work
+**Failures**: Validation failures are reported in the agent output. If code doesn't pass validation, the iteration continues with error feedback to allow Ralph to fix issues.
 
 **License Compliance**: All validation tools use permissive licenses (MIT/Apache/BSD/MPL):
 - Biome: MIT
@@ -462,12 +462,12 @@ graph TD
     Validation --> Scanning[Security Scanning<br/>Trivy]
     Scanning --> GitHub[GitHub PR]
 
-    style Webhook fill:#f9f,stroke:#333
-    style Commands fill:#9ff,stroke:#333
-    style Patterns fill:#9ff,stroke:#333
-    style Resources fill:#9ff,stroke:#333
-    style Paths fill:#9ff,stroke:#333
-    style Scanning fill:#9f9,stroke:#333
+    style Webhook fill:#e1bee7,stroke:#333,color:#000
+    style Commands fill:#b3e5fc,stroke:#333,color:#000
+    style Patterns fill:#b3e5fc,stroke:#333,color:#000
+    style Resources fill:#b3e5fc,stroke:#333,color:#000
+    style Paths fill:#b3e5fc,stroke:#333,color:#000
+    style Scanning fill:#c8e6c9,stroke:#333,color:#000
 ```
 
 ### Command Execution Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,7 +300,7 @@ The tools module (src/tools.ts) auto-detects project type and runs:
 - **Terraform**: terraform fmt (formatting with auto-fix) + terraform validate (syntax validation) + tflint (linting with partial auto-fix)
 - **Security**: Trivy (vulnerability, secret, and misconfiguration scanning - supports Go, Python, JS/TS, Terraform)
 
-Validation failures still result in a push (with "wip:" prefix) to preserve work.
+Validation failures are captured in the output and provided as feedback to the agent for fixing in the next iteration.
 
 ### BullMQ Configuration
 Worker (src/worker.ts:26-30):

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -237,11 +237,12 @@ GET ralph:plan:{issue-id}
 
 ### Validation Failures
 
-Ralph pushes code even if validation fails (with `wip:` prefix).
+If validation fails, Ralph captures the errors and attempts to fix them in the next iteration (up to 3 iterations).
 
-**Check PR**:
-- Look for validation errors in PR description
-- Fix manually or ask Ralph to iterate
+**To fix validation issues**:
+- Ralph will automatically retry with error feedback
+- If all retries fail, comment on the Linear ticket with specific instructions
+- Request a new plan with fixes
 
 ## Advanced Usage
 


### PR DESCRIPTION
## Summary

Fixes two documentation issues:

1. **Defense in Depth diagram colors** - text was unreadable
2. **WIP prefix references** - outdated, no longer in code

## Issue 1: Defense in Depth Diagram

**Problem**: Bright fill colors (#f9f, #9ff, #9f9) made text nearly unreadable without selection.

**Solution**: 
- Changed to pastel colors with better contrast
- Added explicit black text color `color:#000`
- New colors:
  - Webhook: `#e1bee7` (light purple)
  - Commands/Patterns/Resources/Paths: `#b3e5fc` (light blue)  
  - Scanning: `#c8e6c9` (light green)

**Result**: Text is now clearly readable on all diagram nodes.

## Issue 2: WIP Prefix References

**Problem**: Documentation still mentioned `wip:` prefix, but code no longer uses it.

**Changes**:
- **ARCHITECTURE.md**: Updated "Failures" section to describe actual behavior (iteration with error feedback)
- **CLAUDE.md**: Removed WIP prefix mention, documented retry behavior
- **USER_GUIDE.md**: Updated "Validation Failures" section with current automatic retry process

**Current Behavior**: 
- Validation errors are captured
- Agent retries up to 3 times with error feedback
- No WIP commits are created

## Testing

- ✅ All tests passing (8/8 suites, 76/76 tests)
- ✅ TypeScript compilation successful
- ✅ No code changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)