### PR TITLE
docs: update user documentation for Ts.ED architecture

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -68,9 +68,9 @@ graph TB
 
 ## Core Components
 
-### API Server (`src/server.ts`)
+### API Server (`src/Server.ts` + `src/controllers/WebhookController.ts`)
 
-**Purpose**: Webhook ingestion and job enqueueing
+**Purpose**: Webhook ingestion and job enqueueing using Ts.ED framework
 
 **Responsibilities**:
 - Receive and validate Linear webhooks (HMAC SHA-256)
@@ -108,25 +108,28 @@ Ralph's plan comments contain approval keywords in instructions, which could tri
 }
 ```
 
-### Worker (`src/worker.ts`)
+### Worker (`src/services/WorkerService.ts`)
 
-**Purpose**: Job processing and orchestration
+**Purpose**: Job processing and orchestration using Ts.ED dependency injection
 
 **Responsibilities**:
-- Dequeue tasks from Redis
+- Dequeue tasks from Redis (BullMQ worker)
 - Initialize ephemeral workspaces
-- Orchestrate agent execution
-- Handle retry logic
+- Orchestrate agent execution via `AgentOrchestratorService`
+- Handle retry logic and rate limiting
 - Report failures to Linear
+- Auto-starts with API server via `@OnInit()` lifecycle
 
 **Job Types**:
 - `plan-only` - Generate implementation plan
 - `execute-only` - Execute approved plan
 - `full` - Plan + execute (legacy mode)
 
-### Agent (`src/agent.ts`)
+**Note**: With Ts.ED architecture, the Worker runs in the same process as the API server, eliminating the need for separate deployments.
 
-**Purpose**: AI workflow orchestration
+### Agent Orchestrator (`src/services/AgentOrchestratorService.ts`)
+
+**Purpose**: AI workflow orchestration as injectable service
 
 **Responsibilities**:
 - Manage three execution modes (plan-only, execute-only, full)
@@ -147,9 +150,9 @@ const SECURITY_GUARDRAILS = `
 `;
 ```
 
-### Workspace (`src/workspace.ts`)
+### Workspace Manager (`src/domain/WorkspaceManager.ts`)
 
-**Purpose**: Git workspace isolation
+**Purpose**: Git workspace isolation (pure domain logic)
 
 **Responsibilities**:
 - Create UUID-based ephemeral directories (`/tmp/ralph-workspaces/{uuid}`)
@@ -166,9 +169,9 @@ const SECURITY_GUARDRAILS = `
       └── .claude/   # Claude projects cache
 ```
 
-### Tools (`src/tools.ts`)
+### Agent Tools (`src/domain/AgentTools.ts`)
 
-**Purpose**: Polyglot code validation
+**Purpose**: Polyglot code validation (pure domain logic)
 
 **Auto-Detection**:
 - **TypeScript/JavaScript**: Biome + TSC
@@ -447,7 +450,7 @@ To prevent sensitive data from leaking to the LLM (Anthropic), Ralph implements 
 
 **Mechanism**:
 - **Library**: `@redactpii/node` (MIT licensed)
-- **Scope**: Wraps `read_file` and `run_command` in `src/tools.ts`
+- **Scope**: Wraps `readFile` and `runCommand` in `src/domain/AgentTools.ts`
 - **Detection**:
     - **PII**: Emails, IP addresses, Credit Cards, SSN (via built-in rules)
     - **Secrets**: AWS Keys, GitHub Tokens, Linear Keys, Private Keys, Generic API Keys (via Custom Redactors)
@@ -624,13 +627,13 @@ Ralph uses **TOON (Token-Optimized Object Notation)** to reduce context window u
 ```
 JSON (verbose):
 {
-  "files": ["src/agent.ts", "src/server.ts"],
+  "files": ["src/services/AgentOrchestratorService.ts", "src/Server.ts"],
   "status": "active",
   "count": 2
 }
 
 TOON (compact):
-files: src/agent.ts, src/server.ts
+files: src/services/AgentOrchestratorService.ts, src/Server.ts
 status: active
 count: 2
 ```
@@ -650,7 +653,7 @@ Ralph includes custom slash commands that output in TOON format:
 
 Hard limits prevent runaway costs:
 ```typescript
-// src/agent.ts
+// src/services/AgentOrchestratorService.ts
 '--max-budget-usd', '0.50'  // Planning phase
 '--max-budget-usd', '2.00'  // Execution phase
 '--max-budget-usd', '0.10'  // Error summary

--- a/README.md
+++ b/README.md
@@ -120,13 +120,15 @@ npm run build
 # Run tests
 npm test
 
-# Run specific test
-NODE_OPTIONS=--experimental-vm-modules npx jest tests/server.test.ts
+# Run specific test suite
+NODE_OPTIONS=--experimental-vm-modules npx jest tests/controllers/
+NODE_OPTIONS=--experimental-vm-modules npx jest tests/services/
 
-# Start services
-npm run start:api      # API on port 3000
-npm run start:worker   # Background worker
+# Start application (API + Worker in single process)
+npm start              # Starts on port 3000
 ```
+
+**Note**: With Ts.ED architecture, the Worker starts automatically via dependency injection when the API server boots. No need for separate processes.
 
 ## 🔐 Environment Variables
 


### PR DESCRIPTION
## Summary
Updates user-facing documentation (README.md and ARCHITECTURE.md) to accurately reflect the new Ts.ED single-process architecture.

## Changes

### README.md
**Development Commands Section:**
```diff
- npm run start:api      # API on port 3000
- npm run start:worker   # Background worker
+ npm start              # Starts on port 3000
```

**Test Examples:**
```diff
- NODE_OPTIONS=--experimental-vm-modules npx jest tests/server.test.ts
+ NODE_OPTIONS=--experimental-vm-modules npx jest tests/controllers/
+ NODE_OPTIONS=--experimental-vm-modules npx jest tests/services/
```

**Added Note:**
> With Ts.ED architecture, the Worker starts automatically via dependency injection when the API server boots. No need for separate processes.

### ARCHITECTURE.md
Updated all component sections with new file paths and Ts.ED context:

| Old Path | New Path | Update |
|----------|----------|--------|
| `src/server.ts` | `src/Server.ts` + `src/controllers/WebhookController.ts` | Added Ts.ED framework context |
| `src/worker.ts` | `src/services/WorkerService.ts` | Added @OnInit lifecycle note |
| `src/agent.ts` | `src/services/AgentOrchestratorService.ts` | Noted injectable service pattern |
| `src/workspace.ts` | `src/domain/WorkspaceManager.ts` | Marked as pure domain logic |
| `src/tools.ts` | `src/domain/AgentTools.ts` | Marked as pure domain logic |

**Updated Examples:**
- TOON format examples now show current file structure
- Code comments reference correct service paths
- Security section references updated to `AgentTools.ts`

## Impact
- ✅ User-facing documentation now accurate
- ✅ New developers will see correct file structure
- ✅ Development commands work as documented
- ✅ No breaking changes to functionality

## Related
- Follows PR #159 (test cleanup) and PR #160 (config updates)
- Completes Ts.ED refactoring documentation updates
- Makes docs consistent with CLAUDE.md (AI agent documentation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)