### PR TITLE
fix: update deployment entry points for Ts.ED architecture

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,24 +7,14 @@ services:
     volumes:
       - redis_data:/data
 
-  api:
+  ralph:
     build: .
-    command: npm run start:api
+    command: npm start
     ports:
       - "3000:3000"
     environment:
       - REDIS_URL=redis://redis:6379
       - PORT=3000
-    env_file:
-      - .env
-    depends_on:
-      - redis
-
-  worker:
-    build: .
-    command: npm run start:worker
-    environment:
-      - REDIS_URL=redis://redis:6379
     env_file:
       - .env
     depends_on:

--- a/helm/ralph/templates/deployment-api.yaml
+++ b/helm/ralph/templates/deployment-api.yaml
@@ -20,7 +20,7 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          command: ["node", "dist/server.js"]
+          command: ["node", "dist/index.js"]
           ports:
             - containerPort: 3000
           livenessProbe:

--- a/helm/ralph/templates/deployment-worker.yaml
+++ b/helm/ralph/templates/deployment-worker.yaml
@@ -20,7 +20,7 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          command: ["node", "dist/worker.js"]
+          command: ["node", "dist/index.js"]
           volumeMounts:
             - name: workspaces
               mountPath: /tmp/ralph-workspaces


### PR DESCRIPTION
## Summary
Fixes critical deployment failures caused by references to non-existent entry points after Ts.ED refactoring.

## Changes

### docker-compose.yaml
- Merged `api` and `worker` services into single `ralph` service
- Uses `npm start` (which runs `node dist/index.js`)
- Worker auto-starts via `WorkerService` `@OnInit` lifecycle

### helm/ralph/templates/deployment-api.yaml
```diff
- command: ["node", "dist/server.js"]
+ command: ["node", "dist/index.js"]
```

### helm/ralph/templates/deployment-worker.yaml
```diff
- command: ["node", "dist/worker.js"]
+ command: ["node", "dist/index.js"]
```

## Impact
Without these fixes, both `docker-compose up` and Kubernetes deployments fail at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)