### PR TITLE
fix(docker): install curl before using it in RUN step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@ ENV GOPATH="/root/go"
 WORKDIR /app
 
 # Install Go, Terraform, Python, Node Tools, Trivy & Claude CLI
-RUN curl -fsSL https://go.dev/dl/go1.23.5.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
-    go install golang.org/x/tools/cmd/goimports@latest && \
-    go install honnef.co/go/tools/cmd/staticcheck@latest && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends python3 python3-pip python3-venv git curl wget unzip nodejs npm && \
     rm -rf /var/lib/apt/lists/* && \
+    curl -fsSL https://go.dev/dl/go1.23.5.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
+    go install golang.org/x/tools/cmd/goimports@latest && \
+    go install honnef.co/go/tools/cmd/staticcheck@latest && \
     curl -fsSL https://releases.hashicorp.com/terraform/1.7.5/terraform_1.7.5_linux_amd64.zip -o /tmp/terraform.zip && \
     unzip /tmp/terraform.zip -d /usr/local/bin && \
     rm /tmp/terraform.zip && \


### PR DESCRIPTION
## Summary

- `oven/bun:1-debian` does not ship with `curl` pre-installed
- The previous Dockerfile tried to `curl` the Go tarball before running `apt-get install`, which failed with `/bin/sh: 1: curl: not found`
- Fix: move `apt-get update && apt-get install` to the top of the `RUN` step so `curl` is available for all subsequent downloads

## Test plan
- [x] `docker build` completes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)