### PR TITLE
chore: add Renovate for Bun-native dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageManager": "bun",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"]
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"]
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch"],
+      "matchPackagePatterns": ["*"],
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Dependabot doesn't support Bun — it auto-detects `package.json` and creates PRs with `package-lock.json`, which we don't use. Renovate natively supports Bun and updates `bun.lock` directly.

## Config

- **Package manager**: Bun
- **Patch updates**: automerge (safe, no manual review needed)
- **Lockfile maintenance**: weekly (Monday before 6am)
- **Vulnerability alerts**: labeled `security`

## Required action after merge

Install the Renovate GitHub App on this repo:
https://github.com/apps/renovate

Renovate will then open an onboarding PR to confirm the config.

## What to do with the existing Dependabot Hono PR

Close it — Renovate will pick up the same vulnerability and open a proper `bun.lock` PR instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)