### PR TITLE
fix(ci): replace curl|bash Helm install with pinned setup-helm action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -74,8 +74,7 @@ jobs:
 
     # Install Helm
     - name: Install Helm
-      run: |
-        curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+      uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
 
     # Deploy via Helm
     - name: Deploy


### PR DESCRIPTION
## Problem

```yaml
curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
```

`curl | bash` stahuje a spouští skript z internetu bez jakékoliv ověření integrity. Pokud by byl kompromitován Helm repo nebo CDN, spustil by se libovolný kód v CI.

## Fix

Nahrazeno pinned GitHub Action:

```yaml
- uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
```

- SHA-pinned na konkrétní commit (nezmění se bez vědomého update)
- Stejný výsledek — Helm nainstalován a dostupný v `PATH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)