### PR TITLE
feat(ruby-rails): add Ruby on Rails polyglot support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 # Install Go, Terraform, Python, Node Tools, Trivy & Claude CLI
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3 python3-pip python3-venv git curl wget unzip nodejs npm && \
+    apt-get install -y --no-install-recommends python3 python3-pip python3-venv git curl wget unzip nodejs npm ruby ruby-dev && \
     rm -rf /var/lib/apt/lists/* && \
     curl -fsSL https://go.dev/dl/go1.23.5.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
     go install golang.org/x/tools/cmd/goimports@latest && \
@@ -18,6 +18,7 @@ RUN apt-get update && \
     unzip /tmp/tflint.zip -d /usr/local/bin && \
     rm /tmp/tflint.zip && \
     pip3 install --no-cache-dir --break-system-packages ruff mypy uv && \
+    gem install rubocop brakeman bundler-audit --no-document && \
     npm install -g @biomejs/biome typescript tsx @modelcontextprotocol/sdk && \
     curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin && \
     curl -fsSL https://claude.ai/install.sh | bash && \

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -33,6 +33,12 @@ export async function detectProjectLanguages(workDir: string): Promise<string[]>
         languages.push('go');
     }
 
+    // Ruby / Ruby on Rails
+    if (fs.existsSync(path.join(workDir, 'Gemfile'))) {
+        const isRails = fs.existsSync(path.join(workDir, 'config/application.rb'));
+        languages.push(isRails ? 'rails' : 'ruby');
+    }
+
     // Terraform (async check for .tf files)
     try {
         const { stdout } = await execAsync('find . -maxdepth 3 -name "*.tf" -type f | head -1', { cwd: workDir });
@@ -89,6 +95,13 @@ const ALLOWED_COMMAND_PATTERNS = [
     /^staticcheck\s+/,
     /^terraform\s+(init|fmt|validate|plan)/,
     /^tflint\s+/,
+    /^bundle exec (rspec|rails test|rubocop|brakeman|rake)/,
+    /^bundle (install|update)/,
+    /^rails (db:migrate|db:rollback|db:schema:load|routes|generate)/,
+    /^rake (db:migrate|db:rollback|spec|test)/,
+    /^rubocop/,
+    /^brakeman/,
+    /^bundler-audit/,
 ];
 
 const DANGEROUS_PATTERNS = [
@@ -422,6 +435,67 @@ async function validateTerraform(workDir: string, changedFiles: string[]): Promi
     };
 }
 
+async function validateRuby(workDir: string, changedFiles: string[]): Promise<{ success: boolean, log: string }> {
+    const hasGemfile = fs.existsSync(path.join(workDir, 'Gemfile'));
+    if (!hasGemfile) {
+        return { success: true, log: "" };
+    }
+
+    const relevantExtensions = ['.rb', '.rake', '.gemspec'];
+    const hasRelevantChanges = changedFiles.some((f: string) =>
+        relevantExtensions.some(ext => f.endsWith(ext)) || f.includes('Gemfile') || f.includes('Rakefile')
+    );
+
+    if (!hasRelevantChanges) {
+        return { success: true, log: "" };
+    }
+
+    let outputLog = "";
+    let success = true;
+
+    const isRailsProject = fs.existsSync(path.join(workDir, 'config/application.rb'));
+
+    // RuboCop: auto-fix first, then check
+    try {
+        await execAsync('bundle exec rubocop --autocorrect-all --format quiet', { cwd: workDir });
+    } catch { /* auto-fix errors are non-fatal */ }
+    const rubocopResult = await runValidationTool(
+        'bundle exec rubocop --format json',
+        'RuboCop',
+        workDir,
+        changedFiles
+    );
+    success = success && rubocopResult.success;
+    outputLog += rubocopResult.log;
+
+    // Brakeman: security scan, Rails only
+    if (isRailsProject) {
+        const brakemanResult = await runValidationTool(
+            'brakeman --no-pager --format json --quiet',
+            'Brakeman',
+            workDir,
+            changedFiles
+        );
+        success = success && brakemanResult.success;
+        outputLog += brakemanResult.log;
+    }
+
+    // bundler-audit: CVE scan for all Ruby projects
+    try {
+        await execAsync('bundler-audit update', { cwd: workDir });
+    } catch { /* advisory DB update failure is non-fatal */ }
+    const auditResult = await runValidationTool(
+        'bundler-audit check',
+        'bundler-audit',
+        workDir,
+        changedFiles
+    );
+    success = success && auditResult.success;
+    outputLog += auditResult.log;
+
+    return { success, log: outputLog };
+}
+
 async function validateSecurity(workDir: string, changedFiles: string[]): Promise<{ success: boolean, log: string }> {
     let outputLog = "";
     let success = true;
@@ -504,6 +578,10 @@ export async function runPolyglotValidation(workDir: string): Promise<Validation
     const terraformResult = await validateTerraform(workDir, changedFiles);
     allSuccess = allSuccess && terraformResult.success;
     outputLog += terraformResult.log;
+
+    const rubyResult = await validateRuby(workDir, changedFiles);
+    allSuccess = allSuccess && rubyResult.success;
+    outputLog += rubyResult.log;
 
     const securityResult = await validateSecurity(workDir, changedFiles);
     allSuccess = allSuccess && securityResult.success;

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -106,6 +106,21 @@ describe('Agent Tools', () => {
         'terraform fmt',
         'terraform validate',
         'tflint --recursive',
+        'bundle exec rspec',
+        'bundle exec rails test',
+        'bundle exec rubocop',
+        'bundle exec brakeman',
+        'bundle install',
+        'bundle update',
+        'rails db:migrate',
+        'rails db:rollback',
+        'rails routes',
+        'rails generate scaffold Post title:string',
+        'rake db:migrate',
+        'rake spec',
+        'rubocop --format json',
+        'brakeman --no-pager',
+        'bundler-audit check',
     ])('should allow safe whitelisted command: %s', async (cmd) => {
         mockedExec.mockImplementation(createMockExecCallback('ok', ''));
         const result = await runCommand(workDir, cmd);
@@ -140,7 +155,13 @@ describe('runPolyglotValidation', () => {
     const setupProjectDetection = (configFile: string) => {
         mockedFsExistsSync.mockImplementation((p: string) => {
             const normalized = p.replaceAll('\\', '/');
-            return normalized.endsWith(configFile) || (configFile === 'package.json' && (normalized.endsWith('tsconfig.json') || normalized.endsWith('node_modules')));
+            if (configFile === 'package.json') {
+                return normalized.endsWith('package.json') || normalized.endsWith('tsconfig.json') || normalized.endsWith('node_modules');
+            }
+            if (configFile === 'Gemfile+rails') {
+                return normalized.endsWith('Gemfile') || normalized.endsWith('config/application.rb');
+            }
+            return normalized.endsWith(configFile);
         });
     };
 
@@ -183,6 +204,8 @@ describe('runPolyglotValidation', () => {
         ['TypeScript', 'package.json', 'src/agent.ts', ['✅ Biome: Passed', '✅ TSC: Passed']],
         ['Python', 'pyproject.toml', 'main.py', ['✅ Ruff: Passed', '✅ Mypy: Passed']],
         ['Go', 'go.mod', 'main.go', ['✅ goimports: Passed', '✅ staticcheck: Passed', '✅ go build: Passed']],
+        ['Ruby', 'Gemfile', 'app/models/user.rb', ['✅ RuboCop: Passed', '✅ bundler-audit: Passed']],
+        ['Rails', 'Gemfile+rails', 'app/controllers/posts_controller.rb', ['✅ RuboCop: Passed', '✅ Brakeman: Passed', '✅ bundler-audit: Passed']],
     ])('should run %s validation when %s exists', async (_, configFile, changedFile, expectedOutputs) => {
         setupProjectDetection(configFile);
         setupGitStatusMock(`M  ${changedFile}`);


### PR DESCRIPTION
## Summary

- **Dockerfile**: installs `ruby`, `ruby-dev` via apt-get; `rubocop`, `brakeman`, `bundler-audit` via `gem install --no-document`
- **tools.ts – detection**: `detectProjectLanguages()` now detects `Gemfile` → `ruby` or `rails` (when `config/application.rb` also exists)
- **tools.ts – validation**: new `validateRuby()` runs RuboCop autocorrect + check, Brakeman (Rails only), bundler-audit CVE scan; wired into `runPolyglotValidation()`
- **tools.ts – allowlist**: `ALLOWED_COMMAND_PATTERNS` extended with `bundle exec`, `bundle install/update`, `rails db:*`, `rake`, `rubocop`, `brakeman`, `bundler-audit`
- **tests**: 52 tests pass — Ruby and Rails detection cases added; 14 new allowlist commands covered

## Test plan

- [ ] `bun test tests/tools.test.ts` → 52 pass, 0 fail (verified locally)
- [ ] CI green on push
- [ ] `docker build` completes without errors (Ruby toolchain installed)
- [ ] `rubocop --version`, `brakeman --version`, `bundler-audit version` work inside container

🤖 Generated with [Claude Code](https://claude.com/claude-code)