### PR TITLE
chore(helm): add Avvoka team repo mapping placeholder

### DIFF
--- a/helm/ralph/values.yaml
+++ b/helm/ralph/values.yaml
@@ -26,6 +26,8 @@ teamRepos:
   RAL: "https://github.com/Replikanti/ralph-platform"
   WEB: "https://github.com/Replikanti/ralph-platform-web-demo"
   # BACK: "https://github.com/org/backend.git"
+  # Avvoka — map to their main application repository
+  # AVV: "https://github.com/avvoka/main-app"
 
 resources:
   api:


### PR DESCRIPTION
## Summary

- Adds a commented-out `AVV` entry to `teamRepos` in `values.yaml`
- Uncomment and fill in the correct GitHub URL when onboarding Avvoka
- No functional change until activated

## Test plan

- [ ] `helm upgrade --dry-run` passes with no errors
- [ ] Activate by uncommenting + setting repo URL, then `helm upgrade --install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)