### PR TITLE
fix(renovate): remove invalid matchPackagePatterns glob

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,6 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["patch"],
-      "matchPackagePatterns": ["*"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
## Summary

- `matchPackagePatterns` uses regex, not globs — `"*"` is invalid regex
- Removing the filter achieves the same intent (apply automerge to all patch updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)