### PR TITLE
fix(renovate): remove invalid packageManager field

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "packageManager": "bun",
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 6am on monday"]


### PR DESCRIPTION
## Summary

Fixes #184

`"packageManager"` is not a valid Renovate config key and caused the validation error Renovate reported in issue #184. Renovate auto-detects Bun from the presence of `bun.lock` in the repository — no explicit configuration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)