### PR TITLE
fix: skip issue webhook when state is Todo to prevent planning loop

### DIFF
--- a/src/domain/webhook-routing.ts
+++ b/src/domain/webhook-routing.ts
@@ -9,7 +9,8 @@ export function isApprovalComment(body: string): boolean {
 /** Má být issue webhook ignorován? */
 export function shouldSkipIssueWebhook(action: string, stateName: string): boolean {
   if (action !== 'update') return false;
-  const terminal = ['in progress', 'in review', 'completed', 'canceled', 'done'];
+  // 'todo' = awaiting plan approval — re-entry via comment webhook, not issue webhook
+  const terminal = ['in progress', 'in review', 'completed', 'canceled', 'done', 'todo', 'triage', 'backlog', 'unstarted', 'ready'];
   return terminal.includes(stateName.toLowerCase().trim());
 }
 

--- a/tests/domain/webhook-routing.test.ts
+++ b/tests/domain/webhook-routing.test.ts
@@ -24,8 +24,12 @@ describe('webhook-routing', () => {
     });
 
     it('does not skip update in non-terminal states', () => {
-      expect(shouldSkipIssueWebhook('update', 'Todo')).toBe(false);
-      expect(shouldSkipIssueWebhook('update', 'Backlog')).toBe(false);
+      expect(shouldSkipIssueWebhook('update', 'New')).toBe(false);
+    });
+
+    it('skips update when state is Todo (awaiting plan approval — handled by comment webhook)', () => {
+      expect(shouldSkipIssueWebhook('update', 'Todo')).toBe(true);
+      expect(shouldSkipIssueWebhook('update', 'Backlog')).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

When Ralph posts a plan and sets the issue to "Todo", Linear fires an issue update webhook. The handler was re-enqueuing a new planning job because "Todo" was not in the skip list → **infinite planning loop**.

"Todo" = awaiting human approval. The next step is triggered by a **comment** webhook (approval or feedback), not an issue webhook.

Fix: add `todo` and its synonyms (`triage`, `backlog`, `unstarted`, `ready`) to the `shouldSkipIssueWebhook` skip list.

## Test plan

```bash
bun test tests/domain/webhook-routing.test.ts
```

After deploy: submit a Linear task → Ralph posts plan → stays in Todo without re-triggering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)