### PR TITLE
fix(worker): optimize rate limit rotation and handle terminal states

### DIFF
--- a/src/infra/account-pool.ts
+++ b/src/infra/account-pool.ts
@@ -128,6 +128,35 @@ export class AccountPool {
     }
 
     /**
+     * Returns the shortest wait time in milliseconds until an account becomes available.
+     * If an account is already available, returns 0.
+     * If no accounts are configured, returns undefined.
+     */
+    async getShortestWaitTimeMs(): Promise<number | undefined> {
+        if (this.accounts.length === 0) return undefined;
+
+        let shortestWait: number | undefined;
+
+        for (const account of this.accounts) {
+            const key = REDIS_KEY_PREFIX + account.id;
+            const pttl = await this.redis.pttl(key);
+            
+            if (pttl === -2) {
+                // -2 means key does not exist (account is available)
+                return 0;
+            }
+
+            if (pttl > 0) {
+                if (shortestWait === undefined || pttl < shortestWait) {
+                    shortestWait = pttl;
+                }
+            }
+        }
+
+        return shortestWait;
+    }
+
+    /**
      * Seeds Claude credentials from the active account into destDir/.claude/.
      * Copies .credentials.json and settings.json if present.
      */
@@ -158,11 +187,12 @@ export class AccountPool {
 
 const _state: { pool: AccountPool | undefined } = { pool: undefined };
 
-export const accountPool: Pick<AccountPool, 'getCredentialsDir' | 'markRateLimited' | 'hasAvailableAccount' | 'seedCredentials'> = {
+export const accountPool: Pick<AccountPool, 'getCredentialsDir' | 'markRateLimited' | 'hasAvailableAccount' | 'seedCredentials' | 'getShortestWaitTimeMs'> = {
     getCredentialsDir: (...args) => _state.pool!.getCredentialsDir(...args),
     markRateLimited: (...args) => _state.pool!.markRateLimited(...args),
     hasAvailableAccount: (...args) => _state.pool!.hasAvailableAccount(...args),
     seedCredentials: (...args) => _state.pool!.seedCredentials(...args),
+    getShortestWaitTimeMs: (...args) => _state.pool!.getShortestWaitTimeMs(...args),
 };
 
 export function initAccountPool(accountsDir: string, redis: IORedis): void {

--- a/src/infra/claude-runner.ts
+++ b/src/infra/claude-runner.ts
@@ -92,9 +92,38 @@ export function runClaude(args: string[], cwd: string, homeDir: string, timeoutM
             clearTimeout(timeout);
             activeProcesses.delete(child);
 
-            if (stderr.includes('429') || stderr.toLowerCase().includes('rate limit')) {
-                const retryMatch = /retry.{0,20}?(\d+)\s*second/i.exec(stderr + ' ' + stdout);
-                const retryAfterMs = retryMatch ? Number.parseInt(retryMatch[1], 10) * 1000 : undefined;
+            if (stderr.includes('429') || stderr.toLowerCase().includes('rate limit') || stderr.toLowerCase().includes('hit your limit') || stdout.toLowerCase().includes('hit your limit')) {
+                const combinedOutput = stderr + ' ' + stdout;
+                let retryAfterMs: number | undefined;
+
+                const retryMatch = /retry.{0,20}?(\d+)\s*second/i.exec(combinedOutput);
+                if (retryMatch) {
+                    retryAfterMs = Number.parseInt(retryMatch[1], 10) * 1000;
+                } else {
+                    const resetMatch = /resets (.*?) \(UTC\)/i.exec(combinedOutput);
+                    if (resetMatch) {
+                        try {
+                            const dateStr = resetMatch[1];
+                            let formattedDate = dateStr.replace(/am/i, ':00 AM').replace(/pm/i, ':00 PM');
+                            formattedDate = formattedDate.replace(',', `, ${new Date().getUTCFullYear()}`);
+                            const targetTime = Date.parse(`${formattedDate} UTC`);
+                            if (!Number.isNaN(targetTime)) {
+                                let delay = targetTime - Date.now();
+                                if (delay < 0) {
+                                    formattedDate = dateStr.replace(/am/i, ':00 AM').replace(/pm/i, ':00 PM');
+                                    formattedDate = formattedDate.replace(',', `, ${new Date().getUTCFullYear() + 1}`);
+                                    delay = Date.parse(`${formattedDate} UTC`) - Date.now();
+                                }
+                                if (delay > 0) {
+                                    retryAfterMs = delay;
+                                }
+                            }
+                        } catch (e) {
+                            // ignore parsing errors
+                        }
+                    }
+                }
+
                 reject(new RateLimitError("Claude Rate Limit Exceeded", retryAfterMs));
                 return;
             }

--- a/src/infra/claude-runner.ts
+++ b/src/infra/claude-runner.ts
@@ -29,6 +29,40 @@ export interface ClaudeRunConfig {
     allowPermissionBypass?: boolean;
 }
 
+export function parseClaudeRateLimit(stderr: string, stdout: string): number | undefined {
+    const combinedOutput = stderr + ' ' + stdout;
+    
+    const retryMatch = /retry.{0,20}?(\d+)\s*second/i.exec(combinedOutput);
+    if (retryMatch) {
+        return Number.parseInt(retryMatch[1], 10) * 1000;
+    }
+
+    const resetMatch = /resets (.*?) \(UTC\)/i.exec(combinedOutput);
+    if (resetMatch) {
+        try {
+            const dateStr = resetMatch[1];
+            let formattedDate = dateStr.replace(/am/i, ':00 AM').replace(/pm/i, ':00 PM');
+            formattedDate = formattedDate.replace(',', `, ${new Date().getUTCFullYear()}`);
+            
+            const targetTime = Date.parse(`${formattedDate} UTC`);
+            if (Number.isNaN(targetTime)) return undefined;
+
+            let delay = targetTime - Date.now();
+            if (delay < 0) {
+                formattedDate = dateStr.replace(/am/i, ':00 AM').replace(/pm/i, ':00 PM');
+                formattedDate = formattedDate.replace(',', `, ${new Date().getUTCFullYear() + 1}`);
+                delay = Date.parse(`${formattedDate} UTC`) - Date.now();
+            }
+            
+            return delay > 0 ? delay : undefined;
+        } catch (e) {
+            return undefined;
+        }
+    }
+
+    return undefined;
+}
+
 export function runClaudeExecution(config: ClaudeRunConfig, workDir: string, homeDir: string): Promise<{ stdout: string; stderr: string }> {
     const args: string[] = ['-p', config.prompt];
     if (config.model) args.push('--model', config.model);
@@ -93,37 +127,7 @@ export function runClaude(args: string[], cwd: string, homeDir: string, timeoutM
             activeProcesses.delete(child);
 
             if (stderr.includes('429') || stderr.toLowerCase().includes('rate limit') || stderr.toLowerCase().includes('hit your limit') || stdout.toLowerCase().includes('hit your limit')) {
-                const combinedOutput = stderr + ' ' + stdout;
-                let retryAfterMs: number | undefined;
-
-                const retryMatch = /retry.{0,20}?(\d+)\s*second/i.exec(combinedOutput);
-                if (retryMatch) {
-                    retryAfterMs = Number.parseInt(retryMatch[1], 10) * 1000;
-                } else {
-                    const resetMatch = /resets (.*?) \(UTC\)/i.exec(combinedOutput);
-                    if (resetMatch) {
-                        try {
-                            const dateStr = resetMatch[1];
-                            let formattedDate = dateStr.replace(/am/i, ':00 AM').replace(/pm/i, ':00 PM');
-                            formattedDate = formattedDate.replace(',', `, ${new Date().getUTCFullYear()}`);
-                            const targetTime = Date.parse(`${formattedDate} UTC`);
-                            if (!Number.isNaN(targetTime)) {
-                                let delay = targetTime - Date.now();
-                                if (delay < 0) {
-                                    formattedDate = dateStr.replace(/am/i, ':00 AM').replace(/pm/i, ':00 PM');
-                                    formattedDate = formattedDate.replace(',', `, ${new Date().getUTCFullYear() + 1}`);
-                                    delay = Date.parse(`${formattedDate} UTC`) - Date.now();
-                                }
-                                if (delay > 0) {
-                                    retryAfterMs = delay;
-                                }
-                            }
-                        } catch (e) {
-                            // ignore parsing errors
-                        }
-                    }
-                }
-
+                const retryAfterMs = parseClaudeRateLimit(stderr, stdout);
                 reject(new RateLimitError("Claude Rate Limit Exceeded", retryAfterMs));
                 return;
             }

--- a/src/infra/claude-runner.ts
+++ b/src/infra/claude-runner.ts
@@ -39,25 +39,21 @@ export function parseClaudeRateLimit(stderr: string, stdout: string): number | u
 
     const resetMatch = /resets (.*?) \(UTC\)/i.exec(combinedOutput);
     if (resetMatch) {
-        try {
-            const dateStr = resetMatch[1];
-            let formattedDate = dateStr.replace(/am/i, ':00 AM').replace(/pm/i, ':00 PM');
-            formattedDate = formattedDate.replace(',', `, ${new Date().getUTCFullYear()}`);
-            
-            const targetTime = Date.parse(`${formattedDate} UTC`);
-            if (Number.isNaN(targetTime)) return undefined;
+        const dateStr = resetMatch[1];
+        let formattedDate = dateStr.replace(/am/i, ':00 AM').replace(/pm/i, ':00 PM');
+        formattedDate = formattedDate.replace(',', `, ${new Date().getUTCFullYear()}`);
+        
+        const targetTime = Date.parse(`${formattedDate} UTC`);
+        if (Number.isNaN(targetTime)) return undefined;
 
-            let delay = targetTime - Date.now();
-            if (delay < 0) {
-                formattedDate = dateStr.replace(/am/i, ':00 AM').replace(/pm/i, ':00 PM');
-                formattedDate = formattedDate.replace(',', `, ${new Date().getUTCFullYear() + 1}`);
-                delay = Date.parse(`${formattedDate} UTC`) - Date.now();
-            }
-            
-            return delay > 0 ? delay : undefined;
-        } catch (e) {
-            return undefined;
+        let delay = targetTime - Date.now();
+        if (delay < 0) {
+            formattedDate = dateStr.replace(/am/i, ':00 AM').replace(/pm/i, ':00 PM');
+            formattedDate = formattedDate.replace(',', `, ${new Date().getUTCFullYear() + 1}`);
+            delay = Date.parse(`${formattedDate} UTC`) - Date.now();
         }
+        
+        return delay > 0 ? delay : undefined;
     }
 
     return undefined;

--- a/src/platform/server.ts
+++ b/src/platform/server.ts
@@ -197,7 +197,7 @@ async function handlePlanApproval(issueId: string, storedPlan: StoredPlanContext
         description: storedPlan.taskContext.description,
         repoUrl: storedPlan.taskContext.repoUrl,
         branchName: storedPlan.taskContext.branchName,
-        mode: 'execute-only',
+        mode: 'execute-only' as const,
         existingPlan: storedPlan.plan,
         isIteration: storedPlan.taskContext.isIteration
     };
@@ -223,7 +223,7 @@ async function handlePlanRevisionFeedback(issueId: string, storedPlan: StoredPla
         description: storedPlan.taskContext.description,
         repoUrl: storedPlan.taskContext.repoUrl,
         branchName: storedPlan.taskContext.branchName,
-        mode: 'plan-only',
+        mode: 'plan-only' as const,
         additionalFeedback: safeCommentBody
     };
 
@@ -262,7 +262,7 @@ async function handleIterationRequest(routing: { issueId: string; issueTitle: st
         description: safeDescription,
         repoUrl,
         branchName: `ralph/feat-${identifier || issueId}`,
-        mode: 'plan-only',
+        mode: 'plan-only' as const,
         additionalFeedback: safeFeedback,
         isIteration: true
     };

--- a/src/platform/worker.ts
+++ b/src/platform/worker.ts
@@ -58,6 +58,12 @@ async function notifyLinearJobStarted(task: Task): Promise<void> {
     if (!process.env.LINEAR_API_KEY) return;
     try {
         const linearClient = new RalphLinearClient();
+        
+        const currentState = await linearClient.getIssueState(task.ticketId);
+        if (currentState && currentState.toLowerCase() === 'in progress') {
+            return;
+        }
+
         const { ticketId, jobId, mode, isIteration } = task;
 
         if (mode === 'plan-only') {
@@ -143,6 +149,17 @@ async function handleAgentResult(result: AgentResult, task: Task, redis: IORedis
 export const jobProcessor = async (job: Job) => {
     logger.info(`🔨 [Worker] Processing ${job.id} (mode: ${job.data.mode || 'full'})`);
 
+    const linearClient = new RalphLinearClient();
+    const currentState = await linearClient.getIssueState(job.data.ticketId);
+    
+    if (currentState) {
+        const lowerState = currentState.toLowerCase();
+        if (['canceled', 'done', 'rejected', 'duplicate'].includes(lowerState)) {
+            logger.warn(`🛑 [Worker] Job ${job.id} skipped. Linear issue ${job.data.ticketId} is in terminal state: ${currentState}`);
+            return;
+        }
+    }
+
     const taskData: Task = {
         ...job.data,
         jobId: job.id as string,
@@ -175,7 +192,17 @@ export const jobProcessor = async (job: Job) => {
                 // accountPool not configured or other error — fall through to delay
             }
 
-            const delayMs = rateLimitErr.retryAfterMs ?? 60000;
+            let delayMs = rateLimitErr.retryAfterMs ?? 60000;
+            try {
+                const shortestWait = await accountPool.getShortestWaitTimeMs();
+                if (shortestWait !== undefined && shortestWait > 0) {
+                    delayMs = shortestWait;
+                    logger.info(`🔄 [Worker] All accounts rate-limited. Shortest wait time among pool: ${delayMs}ms`);
+                }
+            } catch {
+                // ignore
+            }
+
             logger.warn(`⏳ [Worker] All accounts rate-limited for job ${job.id}. Backing off for ${delayMs}ms...`);
             await job.moveToDelayed(Date.now() + delayMs, job.token);
             return;

--- a/src/platform/worker.ts
+++ b/src/platform/worker.ts
@@ -60,7 +60,7 @@ async function notifyLinearJobStarted(task: Task): Promise<void> {
         const linearClient = new RalphLinearClient();
         
         const currentState = await linearClient.getIssueState(task.ticketId);
-        if (currentState && currentState.toLowerCase() === 'in progress') {
+        if (currentState?.toLowerCase() === 'in progress') {
             return;
         }
 
@@ -144,6 +144,35 @@ async function handleAgentResult(result: AgentResult, task: Task, redis: IORedis
     await updateLinearIssue(ticketId, "Todo", failComment);
 }
 
+async function handleRateLimitError(job: Job, rateLimitErr: RateLimitError): Promise<void> {
+    try {
+        const currentAccountPath = await accountPool.getCredentialsDir();
+        await accountPool.markRateLimited(currentAccountPath, rateLimitErr.retryAfterMs);
+
+        if (await accountPool.hasAvailableAccount()) {
+            logger.info(`🔄 [Worker] Rate limit hit — rotating to next account, immediate retry for job ${job.id}`);
+            await job.retry();
+            return;
+        }
+    } catch {
+        // accountPool not configured or other error — fall through to delay
+    }
+
+    let delayMs = rateLimitErr.retryAfterMs ?? 60000;
+    try {
+        const shortestWait = await accountPool.getShortestWaitTimeMs();
+        if (shortestWait !== undefined && shortestWait > 0) {
+            delayMs = shortestWait;
+            logger.info(`🔄 [Worker] All accounts rate-limited. Shortest wait time among pool: ${delayMs}ms`);
+        }
+    } catch {
+        // ignore
+    }
+
+    logger.warn(`⏳ [Worker] All accounts rate-limited for job ${job.id}. Backing off for ${delayMs}ms...`);
+    await job.moveToDelayed(Date.now() + delayMs, job.token);
+}
+
 // --- Job processor ---
 
 export const jobProcessor = async (job: Job) => {
@@ -178,33 +207,7 @@ export const jobProcessor = async (job: Job) => {
         result = await runAgent(taskData, tracer);
     } catch (e: any) {
         if (e instanceof RateLimitError || e.name === 'RateLimitError') {
-            const rateLimitErr = e as RateLimitError;
-            try {
-                const currentAccountPath = await accountPool.getCredentialsDir();
-                await accountPool.markRateLimited(currentAccountPath, rateLimitErr.retryAfterMs);
-
-                if (await accountPool.hasAvailableAccount()) {
-                    logger.info(`🔄 [Worker] Rate limit hit — rotating to next account, immediate retry for job ${job.id}`);
-                    await job.retry();
-                    return;
-                }
-            } catch {
-                // accountPool not configured or other error — fall through to delay
-            }
-
-            let delayMs = rateLimitErr.retryAfterMs ?? 60000;
-            try {
-                const shortestWait = await accountPool.getShortestWaitTimeMs();
-                if (shortestWait !== undefined && shortestWait > 0) {
-                    delayMs = shortestWait;
-                    logger.info(`🔄 [Worker] All accounts rate-limited. Shortest wait time among pool: ${delayMs}ms`);
-                }
-            } catch {
-                // ignore
-            }
-
-            logger.warn(`⏳ [Worker] All accounts rate-limited for job ${job.id}. Backing off for ${delayMs}ms...`);
-            await job.moveToDelayed(Date.now() + delayMs, job.token);
+            await handleRateLimitError(job, e as RateLimitError);
             return;
         }
         throw e;

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -10,7 +10,13 @@ mock.module('bullmq', () => ({
     Job: mock(),
 }));
 mock.module('ioredis', () => ({
-    default: mock().mockImplementation(() => ({ on: mock() })),
+    default: mock().mockImplementation(() => ({ 
+        on: mock(),
+        get: mock().mockResolvedValue(null),
+        set: mock().mockResolvedValue('OK'),
+        quit: mock().mockResolvedValue('OK'),
+        disconnect: mock()
+    })),
 }));
 mock.module('../src/agent/agent', () => ({
     runAgent: mock(),


### PR DESCRIPTION
This PR adds `getShortestWaitTimeMs` to the `AccountPool` and updates the worker to use the shortest wait time when all accounts are rate-limited. It also parses the 'hit your limit' text from Claude and calculates wait time using UTC date parsing. Finally, it makes the worker skip jobs when the ticket is in a terminal state like Canceled or Done, avoiding infinite loops.